### PR TITLE
Memoization

### DIFF
--- a/bravado_core/model.py
+++ b/bravado_core/model.py
@@ -68,7 +68,6 @@ def _register_visited_model(json_reference, model_spec, model_name, visited_mode
                 model_name, json_reference, visited_models[model_name],
             ),
         )
-    print(model_spec)
     model_spec[MODEL_MARKER] = model_name
     visited_models[model_name] = json_reference
 
@@ -588,8 +587,8 @@ def create_model_type(swagger_spec, model_name, model_spec, bases=(Model,), json
     if 'allOf' in model_spec:
         print('1')
         for schema in model_spec['allOf']:
-            print(swagger_spec.deref(schema))
             inherited_name = swagger_spec.deref(schema).get(MODEL_MARKER, None)
+            print(inherited_name)
             if inherited_name:
                 inherits_from.append(inherited_name)
 
@@ -754,7 +753,7 @@ def _post_process_spec(spec_dict, spec_resolver, on_container_callbacks):
         :type json_reference: str
         """
         if is_dict_like(fragment):
-            for key, value in sorted(iteritems(fragment)):
+            for key, value in iteritems(fragment):
                 json_ref = '{}/{}'.format(json_reference or '', key)
                 fire_callbacks(fragment, json_ref)
                 descend(

--- a/bravado_core/model.py
+++ b/bravado_core/model.py
@@ -193,10 +193,11 @@ def _collect_models(container, json_reference, models, swagger_spec):
     key = json_reference.split('/')[-1]
     if key == MODEL_MARKER and is_object(swagger_spec, container):
         model_spec = swagger_spec.deref(container)
-        #if is_list_like(model_spec):
-        #    model_spec = transfer_list_to_tuple(model_spec)
-        #else:
-        #    model_spec = transform_dict_to_frozendict(model_spec)
+        if is_list_like(model_spec):
+            model_spec = transfer_list_to_tuple(model_spec)
+        else:
+            model_spec = transform_dict_to_frozendict(model_spec)
+        print(model_spec)
         model_name = _get_model_name(container)
         model_type = models.get(model_name)
         if not model_type:

--- a/bravado_core/model.py
+++ b/bravado_core/model.py
@@ -586,7 +586,7 @@ def create_model_type(swagger_spec, model_name, model_spec, bases=(Model,), json
             inherited_name = swagger_spec.deref(schema).get(MODEL_MARKER, None)
             if inherited_name:
                 inherits_from.append(inherited_name)
-
+    print(model_spec)
     return type(str(model_name), bases, dict(
         __doc__=ModelDocstring(),
         _swagger_spec=swagger_spec,

--- a/bravado_core/model.py
+++ b/bravado_core/model.py
@@ -192,7 +192,7 @@ def _collect_models(container, json_reference, models, swagger_spec):
     key = json_reference.split('/')[-1]
     if key == MODEL_MARKER and is_object(swagger_spec, container):
         model_spec = swagger_spec.deref(container)
-        print('ttttt')
+        model_spec = transform_dict_to_frozendict(model_spec)
         model_name = _get_model_name(container)
         model_type = models.get(model_name)
         if not model_type:

--- a/bravado_core/model.py
+++ b/bravado_core/model.py
@@ -191,7 +191,6 @@ def _collect_models(container, json_reference, models, swagger_spec):
         model_spec = swagger_spec.deref(container)
         model_name = _get_model_name(container)
         model_type = models.get(model_name)
-        print(model_name)
         if not model_type:
             models[model_name] = create_model_type(
                 swagger_spec=swagger_spec,

--- a/bravado_core/model.py
+++ b/bravado_core/model.py
@@ -68,7 +68,7 @@ def _register_visited_model(json_reference, model_spec, model_name, visited_mode
                 model_name, json_reference, visited_models[model_name],
             ),
         )
-
+    print(model_name)
     model_spec[MODEL_MARKER] = model_name
     visited_models[model_name] = json_reference
 

--- a/bravado_core/model.py
+++ b/bravado_core/model.py
@@ -588,6 +588,7 @@ def create_model_type(swagger_spec, model_name, model_spec, bases=(Model,), json
             if inherited_name:
                 inherits_from.append(inherited_name)
 
+    print(model_spec)
     return type(str(model_name), bases, dict(
         __doc__=ModelDocstring(),
         _swagger_spec=swagger_spec,

--- a/bravado_core/model.py
+++ b/bravado_core/model.py
@@ -194,6 +194,7 @@ def _collect_models(container, json_reference, models, swagger_spec):
     if key == MODEL_MARKER and is_object(swagger_spec, container):
         model_spec = swagger_spec.deref(container)
         if is_list_like(model_spec):
+            print('ttt')
             model_spec = transfer_list_to_tuple(model_spec)
         else:
             model_spec = transform_dict_to_frozendict(model_spec)

--- a/bravado_core/model.py
+++ b/bravado_core/model.py
@@ -586,7 +586,6 @@ def create_model_type(swagger_spec, model_name, model_spec, bases=(Model,), json
             inherited_name = swagger_spec.deref(schema).get(MODEL_MARKER, None)
             if inherited_name:
                 inherits_from.append(inherited_name)
-    print(model_spec)
     return type(str(model_name), bases, dict(
         __doc__=ModelDocstring(),
         _swagger_spec=swagger_spec,

--- a/bravado_core/model.py
+++ b/bravado_core/model.py
@@ -587,7 +587,7 @@ def create_model_type(swagger_spec, model_name, model_spec, bases=(Model,), json
     inherits_from = []
     if 'allOf' in model_spec:
         for schema in model_spec['allOf']:
-            inherited_name = swagger_spec.deref(schema).get(MODEL_MARKER, None)
+            inherited_name = swagger_spec.fast_deref(schema).get(MODEL_MARKER, None)
             if inherited_name:
                 inherits_from.append(inherited_name)
 
@@ -596,7 +596,7 @@ def create_model_type(swagger_spec, model_name, model_spec, bases=(Model,), json
         _swagger_spec=swagger_spec,
         _model_spec=model_spec,
         _properties=collapsed_properties(model_spec, swagger_spec),
-        _inherits_from=inherits_from,
+        _inherits_from=tuple(inherits_from),
         _json_reference=json_reference,
     ))
 

--- a/bravado_core/model.py
+++ b/bravado_core/model.py
@@ -194,7 +194,6 @@ def _collect_models(container, json_reference, models, swagger_spec):
     if key == MODEL_MARKER and is_object(swagger_spec, container):
         model_spec = swagger_spec.deref(container)
         if is_list_like(model_spec):
-            print('ttt')
             model_spec = transfer_list_to_tuple(model_spec)
         else:
             model_spec = transform_dict_to_frozendict(model_spec)
@@ -766,6 +765,7 @@ def _post_process_spec(spec_dict, spec_resolver, on_container_callbacks):
                 )
 
         elif is_list_like(fragment):
+            print('ttt')
             for index in range(len(fragment)):
                 json_ref = '{}/{}'.format(json_reference or '', index)
                 fire_callbacks(fragment, json_ref)

--- a/bravado_core/model.py
+++ b/bravado_core/model.py
@@ -588,7 +588,7 @@ def create_model_type(swagger_spec, model_name, model_spec, bases=(Model,), json
     if 'allOf' in model_spec:
         print('1')
         for schema in model_spec['allOf']:
-            inherited_name = swagger_spec.fast_deref(schema).get(MODEL_MARKER, None)
+            inherited_name = swagger_spec.deref(schema).get(MODEL_MARKER, None)
             print(inherited_name)
             if inherited_name:
                 inherits_from.append(inherited_name)

--- a/bravado_core/model.py
+++ b/bravado_core/model.py
@@ -65,7 +65,6 @@ def _register_visited_model(json_reference, model_spec, model_name, visited_mode
                 model_name, json_reference, visited_models[model_name],
             ),
         )
-    print(model_name)
     model_spec[MODEL_MARKER] = model_name
     visited_models[model_name] = json_reference
 
@@ -193,6 +192,7 @@ def _collect_models(container, json_reference, models, swagger_spec):
         model_name = _get_model_name(container)
         model_type = models.get(model_name)
         if not model_type:
+            print(model_name)
             models[model_name] = create_model_type(
                 swagger_spec=swagger_spec,
                 model_name=model_name,

--- a/bravado_core/model.py
+++ b/bravado_core/model.py
@@ -192,6 +192,7 @@ def _collect_models(container, json_reference, models, swagger_spec):
     key = json_reference.split('/')[-1]
     if key == MODEL_MARKER and is_object(swagger_spec, container):
         model_spec = transform_dict_to_frozendict(swagger_spec.deref(container))
+        print(model_spec)
         model_name = _get_model_name(container)
         model_type = models.get(model_name)
         if not model_type:

--- a/bravado_core/model.py
+++ b/bravado_core/model.py
@@ -192,6 +192,7 @@ def _collect_models(container, json_reference, models, swagger_spec):
     key = json_reference.split('/')[-1]
     if key == MODEL_MARKER and is_object(swagger_spec, container):
         model_spec = swagger_spec.deref(container)
+        print('ttttt')
         model_name = _get_model_name(container)
         model_type = models.get(model_name)
         if not model_type:

--- a/bravado_core/model.py
+++ b/bravado_core/model.py
@@ -15,6 +15,7 @@ from bravado_core.schema import is_list_like
 from bravado_core.schema import is_ref
 from bravado_core.schema import SWAGGER_PRIMITIVES
 from bravado_core.schema import transform_dict_to_frozendict
+from bravado_core.schema import transfer_list_to_tuple
 from bravado_core.util import determine_object_type
 from bravado_core.util import ObjectType
 from bravado_core.util import strip_xscope
@@ -192,7 +193,10 @@ def _collect_models(container, json_reference, models, swagger_spec):
     key = json_reference.split('/')[-1]
     if key == MODEL_MARKER and is_object(swagger_spec, container):
         model_spec = swagger_spec.deref(container)
-        model_spec = transform_dict_to_frozendict(model_spec)
+        if is_list_like(model_spec):
+            model_spec = transfer_list_to_tuple(model_spec)
+        else:
+            model_spec = transform_dict_to_frozendict(model_spec)
         model_name = _get_model_name(container)
         model_type = models.get(model_name)
         if not model_type:

--- a/bravado_core/model.py
+++ b/bravado_core/model.py
@@ -191,7 +191,6 @@ def _collect_models(container, json_reference, models, swagger_spec):
     :type swagger_spec: :class:`bravado_core.spec.Spec`
     """
     key = json_reference.split('/')[-1]
-    print(key)
     if key == MODEL_MARKER and is_object(swagger_spec, container):
         model_spec = transform_dict_to_frozendict(swagger_spec.deref(container))
         model_name = _get_model_name(container)
@@ -610,6 +609,7 @@ def is_model(swagger_spec, schema_object_spec):
     :return: True if the spec has been "marked" as a model type, false
         otherwise.
     """
+    print(schema_object_spec)
     deref = swagger_spec.deref
     schema_object_spec = deref(schema_object_spec)
     return deref(schema_object_spec.get(MODEL_MARKER)) is not None

--- a/bravado_core/model.py
+++ b/bravado_core/model.py
@@ -585,10 +585,8 @@ def create_model_type(swagger_spec, model_name, model_spec, bases=(Model,), json
 
     inherits_from = []
     if 'allOf' in model_spec:
-        print('1')
         for schema in model_spec['allOf']:
             inherited_name = swagger_spec.deref(schema).get(MODEL_MARKER, None)
-            print(inherited_name)
             if inherited_name:
                 inherits_from.append(inherited_name)
 

--- a/bravado_core/model.py
+++ b/bravado_core/model.py
@@ -609,7 +609,6 @@ def is_model(swagger_spec, schema_object_spec):
     :return: True if the spec has been "marked" as a model type, false
         otherwise.
     """
-    print(schema_object_spec)
     deref = swagger_spec.deref
     schema_object_spec = deref(schema_object_spec)
     return deref(schema_object_spec.get(MODEL_MARKER)) is not None

--- a/bravado_core/model.py
+++ b/bravado_core/model.py
@@ -587,7 +587,6 @@ def create_model_type(swagger_spec, model_name, model_spec, bases=(Model,), json
             if inherited_name:
                 inherits_from.append(inherited_name)
 
-    print(model_spec)
     return type(str(model_name), bases, dict(
         __doc__=ModelDocstring(),
         _swagger_spec=swagger_spec,
@@ -607,6 +606,7 @@ def is_model(swagger_spec, schema_object_spec):
         otherwise.
     """
     deref = swagger_spec.deref
+    print('ttt')
     schema_object_spec = deref(schema_object_spec)
     return deref(schema_object_spec.get(MODEL_MARKER)) is not None
 

--- a/bravado_core/model.py
+++ b/bravado_core/model.py
@@ -193,10 +193,8 @@ def _collect_models(container, json_reference, models, swagger_spec):
     key = json_reference.split('/')[-1]
     if key == MODEL_MARKER and is_object(swagger_spec, container):
         model_spec = swagger_spec.deref(container)
-        if is_list_like(model_spec):
-            model_spec = transfer_list_to_tuple(model_spec)
-        else:
-            model_spec = transform_dict_to_frozendict(model_spec)
+        print(type(model_spec))
+        model_spec = transform_dict_to_frozendict(model_spec)
         model_name = _get_model_name(container)
         model_type = models.get(model_name)
         if not model_type:
@@ -765,7 +763,6 @@ def _post_process_spec(spec_dict, spec_resolver, on_container_callbacks):
                 )
 
         elif is_list_like(fragment):
-            print('ttt')
             for index in range(len(fragment)):
                 json_ref = '{}/{}'.format(json_reference or '', index)
                 fire_callbacks(fragment, json_ref)

--- a/bravado_core/model.py
+++ b/bravado_core/model.py
@@ -68,6 +68,7 @@ def _register_visited_model(json_reference, model_spec, model_name, visited_mode
                 model_name, json_reference, visited_models[model_name],
             ),
         )
+    print(model_spec)
     model_spec[MODEL_MARKER] = model_name
     visited_models[model_name] = json_reference
 
@@ -192,7 +193,6 @@ def _collect_models(container, json_reference, models, swagger_spec):
     key = json_reference.split('/')[-1]
     if key == MODEL_MARKER and is_object(swagger_spec, container):
         model_spec = transform_dict_to_frozendict(swagger_spec.deref(container))
-        print(model_spec)
         model_name = _get_model_name(container)
         model_type = models.get(model_name)
         if not model_type:

--- a/bravado_core/model.py
+++ b/bravado_core/model.py
@@ -197,6 +197,7 @@ def _collect_models(container, json_reference, models, swagger_spec):
             model_spec = transfer_list_to_tuple(model_spec)
         else:
             model_spec = transform_dict_to_frozendict(model_spec)
+        print(model_spec)
         model_name = _get_model_name(container)
         model_type = models.get(model_name)
         if not model_type:

--- a/bravado_core/model.py
+++ b/bravado_core/model.py
@@ -608,7 +608,6 @@ def is_model(swagger_spec, schema_object_spec):
     """
     deref = swagger_spec.deref
     schema_object_spec = deref(schema_object_spec)
-    print(deref(schema_object_spec.get(MODEL_MARKER)))
     return deref(schema_object_spec.get(MODEL_MARKER)) is not None
 
 

--- a/bravado_core/model.py
+++ b/bravado_core/model.py
@@ -191,6 +191,7 @@ def _collect_models(container, json_reference, models, swagger_spec):
     :type swagger_spec: :class:`bravado_core.spec.Spec`
     """
     key = json_reference.split('/')[-1]
+    print(key)
     if key == MODEL_MARKER and is_object(swagger_spec, container):
         model_spec = transform_dict_to_frozendict(swagger_spec.deref(container))
         model_name = _get_model_name(container)
@@ -611,7 +612,6 @@ def is_model(swagger_spec, schema_object_spec):
     """
     deref = swagger_spec.deref
     schema_object_spec = deref(schema_object_spec)
-    print(schema_object_spec)
     return deref(schema_object_spec.get(MODEL_MARKER)) is not None
 
 

--- a/bravado_core/model.py
+++ b/bravado_core/model.py
@@ -193,10 +193,10 @@ def _collect_models(container, json_reference, models, swagger_spec):
     key = json_reference.split('/')[-1]
     if key == MODEL_MARKER and is_object(swagger_spec, container):
         model_spec = swagger_spec.deref(container)
-        if is_list_like(model_spec):
-            model_spec = transfer_list_to_tuple(model_spec)
-        else:
-            model_spec = transform_dict_to_frozendict(model_spec)
+        #if is_list_like(model_spec):
+        #    model_spec = transfer_list_to_tuple(model_spec)
+        #else:
+        #    model_spec = transform_dict_to_frozendict(model_spec)
         model_name = _get_model_name(container)
         model_type = models.get(model_name)
         if not model_type:

--- a/bravado_core/model.py
+++ b/bravado_core/model.py
@@ -65,6 +65,7 @@ def _register_visited_model(json_reference, model_spec, model_name, visited_mode
                 model_name, json_reference, visited_models[model_name],
             ),
         )
+    print(model_name)
     model_spec[MODEL_MARKER] = model_name
     visited_models[model_name] = json_reference
 

--- a/bravado_core/model.py
+++ b/bravado_core/model.py
@@ -588,8 +588,8 @@ def create_model_type(swagger_spec, model_name, model_spec, bases=(Model,), json
     if 'allOf' in model_spec:
         print('1')
         for schema in model_spec['allOf']:
+            print(swagger_spec.deref(schema))
             inherited_name = swagger_spec.deref(schema).get(MODEL_MARKER, None)
-            print(inherited_name)
             if inherited_name:
                 inherits_from.append(inherited_name)
 

--- a/bravado_core/model.py
+++ b/bravado_core/model.py
@@ -193,7 +193,7 @@ def _collect_models(container, json_reference, models, swagger_spec):
     key = json_reference.split('/')[-1]
     if key == MODEL_MARKER and is_object(swagger_spec, container):
         model_spec = swagger_spec.deref(container)
-        print(type(model_spec))
+        print(model_spec)
         model_spec = transform_dict_to_frozendict(model_spec)
         model_name = _get_model_name(container)
         model_type = models.get(model_name)

--- a/bravado_core/model.py
+++ b/bravado_core/model.py
@@ -611,6 +611,7 @@ def is_model(swagger_spec, schema_object_spec):
     """
     deref = swagger_spec.deref
     schema_object_spec = deref(schema_object_spec)
+    print(schema_object_spec)
     return deref(schema_object_spec.get(MODEL_MARKER)) is not None
 
 

--- a/bravado_core/model.py
+++ b/bravado_core/model.py
@@ -583,7 +583,6 @@ def create_model_type(swagger_spec, model_name, model_spec, bases=(Model,), json
     inherits_from = []
     if 'allOf' in model_spec:
         for schema in model_spec['allOf']:
-            print(swagger_spec.deref(schema))
             inherited_name = swagger_spec.deref(schema).get(MODEL_MARKER, None)
             if inherited_name:
                 inherits_from.append(inherited_name)
@@ -609,6 +608,7 @@ def is_model(swagger_spec, schema_object_spec):
     """
     deref = swagger_spec.deref
     schema_object_spec = deref(schema_object_spec)
+    print(schema_object_spec)
     return deref(schema_object_spec.get(MODEL_MARKER)) is not None
 
 

--- a/bravado_core/model.py
+++ b/bravado_core/model.py
@@ -608,7 +608,7 @@ def is_model(swagger_spec, schema_object_spec):
     """
     deref = swagger_spec.deref
     schema_object_spec = deref(schema_object_spec)
-    print(schema_object_spec)
+    print(deref(schema_object_spec.get(MODEL_MARKER)))
     return deref(schema_object_spec.get(MODEL_MARKER)) is not None
 
 

--- a/bravado_core/model.py
+++ b/bravado_core/model.py
@@ -191,6 +191,7 @@ def _collect_models(container, json_reference, models, swagger_spec):
         model_spec = swagger_spec.deref(container)
         model_name = _get_model_name(container)
         model_type = models.get(model_name)
+        print(model_name)
         if not model_type:
             models[model_name] = create_model_type(
                 swagger_spec=swagger_spec,

--- a/bravado_core/model.py
+++ b/bravado_core/model.py
@@ -591,7 +591,7 @@ def create_model_type(swagger_spec, model_name, model_spec, bases=(Model,), json
             if inherited_name:
                 inherits_from.append(inherited_name)
 
-    return type(str(model_name), bases, dict(
+    return type(str(model_name), bases, frozendict(
         __doc__=ModelDocstring(),
         _swagger_spec=swagger_spec,
         _model_spec=model_spec,

--- a/bravado_core/model.py
+++ b/bravado_core/model.py
@@ -194,7 +194,6 @@ def _collect_models(container, json_reference, models, swagger_spec):
     if key == MODEL_MARKER and is_object(swagger_spec, container):
         model_spec = transform_dict_to_frozendict(swagger_spec.deref(container))
         model_name = _get_model_name(container)
-        print(model_name)
         model_type = models.get(model_name)
         if not model_type:
             models[model_name] = create_model_type(

--- a/bravado_core/model.py
+++ b/bravado_core/model.py
@@ -192,7 +192,6 @@ def _collect_models(container, json_reference, models, swagger_spec):
         model_name = _get_model_name(container)
         model_type = models.get(model_name)
         if not model_type:
-            print(model_name)
             models[model_name] = create_model_type(
                 swagger_spec=swagger_spec,
                 model_name=model_name,
@@ -584,6 +583,7 @@ def create_model_type(swagger_spec, model_name, model_spec, bases=(Model,), json
     inherits_from = []
     if 'allOf' in model_spec:
         for schema in model_spec['allOf']:
+            print(swagger_spec.deref(schema))
             inherited_name = swagger_spec.deref(schema).get(MODEL_MARKER, None)
             if inherited_name:
                 inherits_from.append(inherited_name)

--- a/bravado_core/model.py
+++ b/bravado_core/model.py
@@ -591,7 +591,7 @@ def create_model_type(swagger_spec, model_name, model_spec, bases=(Model,), json
             if inherited_name:
                 inherits_from.append(inherited_name)
 
-    return type(str(model_name), bases, frozendict(
+    return type(str(model_name), bases, dict(
         __doc__=ModelDocstring(),
         _swagger_spec=swagger_spec,
         _model_spec=model_spec,

--- a/bravado_core/model.py
+++ b/bravado_core/model.py
@@ -586,8 +586,10 @@ def create_model_type(swagger_spec, model_name, model_spec, bases=(Model,), json
 
     inherits_from = []
     if 'allOf' in model_spec:
+        print('1')
         for schema in model_spec['allOf']:
             inherited_name = swagger_spec.fast_deref(schema).get(MODEL_MARKER, None)
+            print(inherited_name)
             if inherited_name:
                 inherits_from.append(inherited_name)
 

--- a/bravado_core/model.py
+++ b/bravado_core/model.py
@@ -194,6 +194,7 @@ def _collect_models(container, json_reference, models, swagger_spec):
     if key == MODEL_MARKER and is_object(swagger_spec, container):
         model_spec = transform_dict_to_frozendict(swagger_spec.deref(container))
         model_name = _get_model_name(container)
+        print(model_name)
         model_type = models.get(model_name)
         if not model_type:
             models[model_name] = create_model_type(

--- a/bravado_core/model.py
+++ b/bravado_core/model.py
@@ -192,9 +192,7 @@ def _collect_models(container, json_reference, models, swagger_spec):
     """
     key = json_reference.split('/')[-1]
     if key == MODEL_MARKER and is_object(swagger_spec, container):
-        model_spec = swagger_spec.deref(container)
-        print(model_spec)
-        model_spec = transform_dict_to_frozendict(model_spec)
+        model_spec = transform_dict_to_frozendict(swagger_spec.deref(container))
         model_name = _get_model_name(container)
         model_type = models.get(model_name)
         if not model_type:

--- a/bravado_core/model.py
+++ b/bravado_core/model.py
@@ -68,7 +68,6 @@ def _register_visited_model(json_reference, model_spec, model_name, visited_mode
                 model_name, json_reference, visited_models[model_name],
             ),
         )
-    print(model_name)
     model_spec[MODEL_MARKER] = model_name
     visited_models[model_name] = json_reference
 

--- a/bravado_core/model.py
+++ b/bravado_core/model.py
@@ -606,7 +606,6 @@ def is_model(swagger_spec, schema_object_spec):
         otherwise.
     """
     deref = swagger_spec.deref
-    print('ttt')
     schema_object_spec = deref(schema_object_spec)
     return deref(schema_object_spec.get(MODEL_MARKER)) is not None
 

--- a/bravado_core/model.py
+++ b/bravado_core/model.py
@@ -197,7 +197,6 @@ def _collect_models(container, json_reference, models, swagger_spec):
             model_spec = transfer_list_to_tuple(model_spec)
         else:
             model_spec = transform_dict_to_frozendict(model_spec)
-        print(model_spec)
         model_name = _get_model_name(container)
         model_type = models.get(model_name)
         if not model_type:

--- a/bravado_core/model.py
+++ b/bravado_core/model.py
@@ -14,12 +14,9 @@ from bravado_core.schema import is_dict_like
 from bravado_core.schema import is_list_like
 from bravado_core.schema import is_ref
 from bravado_core.schema import SWAGGER_PRIMITIVES
-from bravado_core.schema import transform_dict_to_frozendict
-from bravado_core.schema import transfer_list_to_tuple
 from bravado_core.util import determine_object_type
 from bravado_core.util import ObjectType
 from bravado_core.util import strip_xscope
-from frozendict import frozendict
 
 log = logging.getLogger(__name__)
 
@@ -191,7 +188,7 @@ def _collect_models(container, json_reference, models, swagger_spec):
     """
     key = json_reference.split('/')[-1]
     if key == MODEL_MARKER and is_object(swagger_spec, container):
-        model_spec = transform_dict_to_frozendict(swagger_spec.deref(container))
+        model_spec = swagger_spec.deref(container)
         model_name = _get_model_name(container)
         model_type = models.get(model_name)
         if not model_type:

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -84,7 +84,6 @@ def is_frozendict_like(spec):
     return isinstance(spec, frozendict)
 
 def transform_dict_to_frozendict(spec):
-    print('ttttttt')
     for key, value in iteritems(spec):
         if is_list_like(value):
             spec[key] = transfer_list_to_tuple(value)

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -166,7 +166,7 @@ def collapsed_properties(model_spec, swagger_spec):
 
     i = id(model_spec)
     try:
-        return cache[id]
+        return swagger_spec.cache[id]
     except KeyError:
         properties = {}
 
@@ -182,5 +182,5 @@ def collapsed_properties(model_spec, swagger_spec):
                 item_spec = deref(item_spec)
                 more_properties = collapsed_properties(item_spec, swagger_spec)
                 properties.update(more_properties)
-        cache[i] = properties
+        swagger_spec.cache[i] = properties
         return properties

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -6,6 +6,7 @@ from six import iteritems
 
 from bravado_core.exception import SwaggerMappingError
 from frozendict import frozendict
+from fastcache import clru_cache
 
 
 # 'object' and 'array' are omitted since this should really be read as

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -138,7 +138,7 @@ def get_spec_for_prop(swagger_spec, object_spec, object_value, prop_name, proper
     if properties is None:
         properties = collapsed_properties(deref(object_spec), swagger_spec)
     prop_spec = properties.get(prop_name)
-    #print(prop_spec)
+    print(prop_name)
 
     if prop_spec is not None:
         result_spec = deref(prop_spec)
@@ -157,7 +157,6 @@ def get_spec_for_prop(swagger_spec, object_spec, object_value, prop_name, proper
         #return result_spec
 
     additional_props = deref(object_spec).get('additionalProperties', True)
-    print('ttt')
 
     if isinstance(additional_props, bool):
         # no spec for additional properties to conform to - this is basically

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -168,7 +168,7 @@ def collapsed_properties(model_spec, swagger_spec):
     try:
         return cache[i]
     except KeyError:
-        print(model_spec)
+        #print(model_spec)
         properties = {}
 
     # properties may or may not be present

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -84,7 +84,6 @@ def is_frozendict_like(spec):
     return isinstance(spec, frozendict)
 
 def transform_dict_to_frozendict(spec):
-    print('lllll')
     for key, value in iteritems(spec):
         if is_list_like(value):
             spec[key] = transfer_list_to_tuple(value)

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -84,6 +84,7 @@ def is_frozendict_like(spec):
     return isinstance(spec, frozendict)
 
 def transform_dict_to_frozendict(spec):
+    print(spec)
     for key, value in iteritems(spec):
         if is_list_like(value):
             spec[key] = transfer_list_to_tuple(value)

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -223,4 +223,4 @@ def collapsed_properties(model_spec, swagger_spec):
             more_properties = collapsed_properties(item_spec, swagger_spec)
             properties.update(more_properties)
 
-    return frozendict(properties)
+    return properties

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -208,7 +208,6 @@ def collapsed_properties(model_spec, swagger_spec):
     """
 
     properties = {}
-    print('ttt')
 
     # properties may or may not be present
     if 'properties' in model_spec:

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -18,7 +18,7 @@ SWAGGER_PRIMITIVES = (
     'boolean',
     'null',
 )
-cache = {}
+
 
 def has_default(swagger_spec, schema_object_spec):
     return 'default' in swagger_spec.deref(schema_object_spec)
@@ -189,7 +189,7 @@ def handle_null_value(swagger_spec, schema_object_spec):
     raise SwaggerMappingError(
         'Spec {0} is a required value'.format(schema_object_spec))
 
-#@lru_cache(maxsize=10)
+@lru_cache(maxsize=10)
 def collapsed_properties(model_spec, swagger_spec):
     """Processes model spec and outputs dictionary with attributes
     as the keys and attribute spec as the value for the model.
@@ -202,24 +202,20 @@ def collapsed_properties(model_spec, swagger_spec):
     :param swagger_spec: :class:`bravado_core.spec.Spec`
     :returns: dict
     """
-    i = id(model_spec)
-    try:
-        return cache[i]
-    except KeyError:
-        properties = {}
+
+    properties = {}
 
     # properties may or may not be present
-        if 'properties' in model_spec:
-            for attr, attr_spec in iteritems(model_spec['properties']):
-                properties[attr] = attr_spec
+    if 'properties' in model_spec:
+        for attr, attr_spec in iteritems(model_spec['properties']):
+            properties[attr] = attr_spec
 
     # allOf may or may not be present
-        if 'allOf' in model_spec:
-            deref = swagger_spec.fast_deref
-            for item_spec in model_spec['allOf']:
-                item_spec = deref(item_spec)
-                more_properties = collapsed_properties(item_spec, swagger_spec)
-                properties.update(more_properties)
+    if 'allOf' in model_spec:
+        deref = swagger_spec.fast_deref
+        for item_spec in model_spec['allOf']:
+            item_spec = deref(item_spec)
+            more_properties = collapsed_properties(item_spec, swagger_spec)
+            properties.update(more_properties)
 
-        cache[i] = properties
-        return properties
+    return properties

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -117,7 +117,7 @@ def is_list_like(spec):
     """
     return isinstance(spec, (list, tuple))
 
-
+@lru_cache(maxsize=100)
 def get_spec_for_prop(swagger_spec, object_spec, object_value, prop_name, properties=None):
     """Given a jsonschema object spec and value, retrieve the spec for the
      given property taking 'additionalProperties' into consideration.

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -87,7 +87,7 @@ def transform_dict_to_frozendict(spec):
     for key, value in iteritems(spec):
         if is_list_like(value):
             spec[key] = transfer_list_to_tuple(value)
-        elif is_dict_like(value) and not is_frozendict_like(value):
+        elif not is_frozendict_like(value) and is_dict_like(value):
             spec[key] = transform_dict_to_frozendict(value)
 
     if is_frozendict_like(spec):
@@ -100,7 +100,7 @@ def transfer_list_to_tuple(spec):
     for item in spec:
         if is_list_like(item):
             array.append(transfer_list_to_tuple(item))
-        elif is_dict_like(item) and not is_frozendict_like(item):
+        elif not is_frozendict_like(item) and is_dict_like(item):
             array.append(transform_dict_to_frozendict(item))
         else:
             array.append(item)

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -189,7 +189,7 @@ def handle_null_value(swagger_spec, schema_object_spec):
     raise SwaggerMappingError(
         'Spec {0} is a required value'.format(schema_object_spec))
 
-
+@clru_cache(maxsize=325, typed=False)
 def collapsed_properties(model_spec, swagger_spec):
     """Processes model spec and outputs dictionary with attributes
     as the keys and attribute spec as the value for the model.

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -95,41 +95,48 @@ def get_spec_for_prop(swagger_spec, object_spec, object_value, prop_name, proper
     :return: spec for the given property or None if no spec found
     :rtype: dict or None
     """
-    deref = swagger_spec.fast_deref
 
-    if properties is None:
-        properties = collapsed_properties(deref(object_spec), swagger_spec)
-    prop_spec = properties.get(prop_name)
+    i = id(prop_name)
+    try:
+        return cache[i]
+    except KeyError:
+        deref = swagger_spec.fast_deref
 
-    if prop_spec is not None:
-        result_spec = deref(prop_spec)
+        if properties is None:
+            properties = collapsed_properties(deref(object_spec), swagger_spec)
+        prop_spec = properties.get(prop_name)
+
+        if prop_spec is not None:
+            result_spec = deref(prop_spec)
         # If the de-referenced specification is for a x-nullable property
         # then copy the spec and add the x-nullable property.
         # If in the future there are other attributes on the property that
         # modify a referenced schema, it can be done here (or rewrite
         # unmarshal to pass the unreferenced property spec as another arg).
-        if 'x-nullable' in prop_spec and 'x-nullable' not in result_spec:
-            result_spec = copy.deepcopy(result_spec)
-            result_spec['x-nullable'] = prop_spec['x-nullable']
+            if 'x-nullable' in prop_spec and 'x-nullable' not in result_spec:
+                result_spec = copy.deepcopy(result_spec)
+                result_spec['x-nullable'] = prop_spec['x-nullable']
 
-        return result_spec
+            cache[i] = result_spec
+            return result_spec
 
-    print('tttttttttt')
-    additional_props = deref(object_spec).get('additionalProperties', True)
+        additional_props = deref(object_spec).get('additionalProperties', True)
 
-    if isinstance(additional_props, bool):
+        if isinstance(additional_props, bool):
         # no spec for additional properties to conform to - this is basically
         # a way to send pretty much anything across the wire as is.
-        return None
+            cache[i] = None
+            return None
 
-    additional_props = deref(additional_props)
-    if is_dict_like(additional_props):
+        additional_props = deref(additional_props)
+        if is_dict_like(additional_props):
         # spec that all additional props MUST conform to
-        return additional_props
+            cache[i] = additional_props
+            return additional_props
 
-    raise SwaggerMappingError(
-        "Don't know what to do with `additionalProperties` in spec {0} "
-        "when inspecting value {1}".format(object_spec, object_value))
+        raise SwaggerMappingError(
+            "Don't know what to do with `additionalProperties` in spec {0} "
+            "when inspecting value {1}".format(object_spec, object_value))
 
 
 def handle_null_value(swagger_spec, schema_object_spec):

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -100,7 +100,8 @@ def get_spec_for_prop(swagger_spec, object_spec, object_value, prop_name, proper
     if properties is None:
         properties = collapsed_properties(deref(object_spec), swagger_spec)
     prop_spec = properties.get(prop_name)
-    print(prop_name + '       ' + prop_spec)
+    print(prop_name)
+    print(prop_spec)
 
     if prop_spec is not None:
         result_spec = deref(prop_spec)

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -157,6 +157,7 @@ def get_spec_for_prop(swagger_spec, object_spec, object_value, prop_name, proper
         #return result_spec
 
     additional_props = deref(object_spec).get('additionalProperties', True)
+    print('ttt')
 
     if isinstance(additional_props, bool):
         # no spec for additional properties to conform to - this is basically

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -137,6 +137,7 @@ def get_spec_for_prop(swagger_spec, object_spec, object_value, prop_name, proper
     if properties is None:
         properties = collapsed_properties(deref(object_spec), swagger_spec)
     prop_spec = properties.get(prop_name)
+    print(prop_spec)
 
     if prop_spec is not None:
         result_spec = deref(prop_spec)

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -138,7 +138,6 @@ def get_spec_for_prop(swagger_spec, object_spec, object_value, prop_name, proper
     if properties is None:
         properties = collapsed_properties(deref(object_spec), swagger_spec)
     prop_spec = properties.get(prop_name)
-    print(prop_name)
 
     if prop_spec is not None:
         result_spec = deref(prop_spec)
@@ -208,6 +207,7 @@ def collapsed_properties(model_spec, swagger_spec):
     """
 
     properties = {}
+    print(model_spec)
 
     # properties may or may not be present
     if 'properties' in model_spec:

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -189,7 +189,7 @@ def handle_null_value(swagger_spec, schema_object_spec):
     raise SwaggerMappingError(
         'Spec {0} is a required value'.format(schema_object_spec))
 
-@clru_cache(maxsize=325, typed=False)
+@clru_cache(maxsize=100, typed=False)
 def collapsed_properties(model_spec, swagger_spec):
     """Processes model spec and outputs dictionary with attributes
     as the keys and attribute spec as the value for the model.

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -194,7 +194,7 @@ def handle_null_value(swagger_spec, schema_object_spec):
     raise SwaggerMappingError(
         'Spec {0} is a required value'.format(schema_object_spec))
 
-@lru_cache(maxsize=100)
+@lru_cache(maxsize=10)
 def collapsed_properties(model_spec, swagger_spec):
     """Processes model spec and outputs dictionary with attributes
     as the keys and attribute spec as the value for the model.

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -100,7 +100,7 @@ def get_spec_for_prop(swagger_spec, object_spec, object_value, prop_name, proper
     if properties is None:
         properties = collapsed_properties(deref(object_spec), swagger_spec)
     prop_spec = properties.get(prop_name)
-    print(prop_name)
+    print(prop_name + '       ' + prop_spec)
 
     if prop_spec is not None:
         result_spec = deref(prop_spec)

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -100,7 +100,7 @@ def get_spec_for_prop(swagger_spec, object_spec, object_value, prop_name, proper
     try:
         return cache[i]
     except KeyError:
-        deref = swagger_spec.fast_deref
+        deref = swagger_spec.deref
 
         if properties is None:
             properties = collapsed_properties(deref(object_spec), swagger_spec)

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -84,7 +84,7 @@ def is_frozendict_like(spec):
     return isinstance(spec, frozendict)
 
 def transform_dict_to_frozendict(spec):
-    print(spec)
+    #print(spec)
     for key, value in iteritems(spec):
         if is_list_like(value):
             spec[key] = transfer_list_to_tuple(value)

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -164,7 +164,7 @@ def collapsed_properties(model_spec, swagger_spec):
     :returns: dict
     """
 
-    id = id(model_spec)
+    i = id(model_spec)
     try:
         return cache[id]
     except KeyError:
@@ -182,5 +182,5 @@ def collapsed_properties(model_spec, swagger_spec):
                 item_spec = deref(item_spec)
                 more_properties = collapsed_properties(item_spec, swagger_spec)
                 properties.update(more_properties)
-        cache[id] = properties
+        cache[i] = properties
         return properties

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -150,6 +150,8 @@ def get_spec_for_prop(swagger_spec, object_spec, object_value, prop_name, proper
         if 'x-nullable' in prop_spec and 'x-nullable' not in result_spec:
             result_spec = copy.deepcopy(result_spec)
             result_spec['x-nullable'] = prop_spec['x-nullable']
+        if not is_frozendict_like(result_spec):
+            return transform_dict_to_frozendict(result_spec)
         return result_spec
 
     additional_props = deref(object_spec).get('additionalProperties', True)

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -223,4 +223,4 @@ def collapsed_properties(model_spec, swagger_spec):
             more_properties = collapsed_properties(item_spec, swagger_spec)
             properties.update(more_properties)
 
-    return properties
+    return frozendict(properties)

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -95,7 +95,7 @@ def get_spec_for_prop(swagger_spec, object_spec, object_value, prop_name, proper
     :return: spec for the given property or None if no spec found
     :rtype: dict or None
     """
-    deref = swagger_spec.deref
+    deref = swagger_spec.fast_deref
 
     if properties is None:
         properties = collapsed_properties(deref(object_spec), swagger_spec)
@@ -177,7 +177,7 @@ def collapsed_properties(model_spec, swagger_spec):
 
     # allOf may or may not be present
         if 'allOf' in model_spec:
-            deref = swagger_spec.deref
+            deref = swagger_spec.fast_deref
             for item_spec in model_spec['allOf']:
                 item_spec = deref(item_spec)
                 more_properties = collapsed_properties(item_spec, swagger_spec)

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -137,7 +137,7 @@ def get_spec_for_prop(swagger_spec, object_spec, object_value, prop_name, proper
     if properties is None:
         properties = collapsed_properties(deref(object_spec), swagger_spec)
     prop_spec = properties.get(prop_name)
-    print(prop_spec)
+    print(prop_name)
 
     if prop_spec is not None:
         result_spec = deref(prop_spec)

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -168,6 +168,7 @@ def collapsed_properties(model_spec, swagger_spec):
     try:
         return cache[id]
     except KeyError:
+        print(id)
         properties = {}
 
     # properties may or may not be present

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -16,7 +16,7 @@ SWAGGER_PRIMITIVES = (
     'boolean',
     'null',
 )
-cache = {}
+#cache = {}
 
 def has_default(swagger_spec, schema_object_spec):
     return 'default' in swagger_spec.deref(schema_object_spec)
@@ -98,7 +98,7 @@ def get_spec_for_prop(swagger_spec, object_spec, object_value, prop_name, proper
 
     i = id(prop_name)
     try:
-        return swagger_spec.cache[i]
+        return swagger_spec.cache_schema[i]
     except KeyError:
         deref = swagger_spec.fast_deref
 
@@ -117,7 +117,7 @@ def get_spec_for_prop(swagger_spec, object_spec, object_value, prop_name, proper
                 result_spec = copy.deepcopy(result_spec)
                 result_spec['x-nullable'] = prop_spec['x-nullable']
 
-            swagger_spec.cache[i] = result_spec
+            swagger_spec.cache_schema[i] = result_spec
             return result_spec
 
         additional_props = deref(object_spec).get('additionalProperties', True)
@@ -125,13 +125,13 @@ def get_spec_for_prop(swagger_spec, object_spec, object_value, prop_name, proper
         if isinstance(additional_props, bool):
         # no spec for additional properties to conform to - this is basically
         # a way to send pretty much anything across the wire as is.
-            swagger_spec.cache[i] = None
+            swagger_spec.cache_schema[i] = None
             return None
 
         additional_props = deref(additional_props)
         if is_dict_like(additional_props):
         # spec that all additional props MUST conform to
-            swagger_spec.cache[i] = additional_props
+            swagger_spec.cache_schema[i] = additional_props
             return additional_props
 
         raise SwaggerMappingError(
@@ -174,7 +174,7 @@ def collapsed_properties(model_spec, swagger_spec):
 
     i = id(model_spec)
     try:
-        return swagger_spec.cache[i]
+        return swagger_spec.cache_schema[i]
     except KeyError:
         #print(model_spec)
         properties = {}
@@ -191,5 +191,5 @@ def collapsed_properties(model_spec, swagger_spec):
                 item_spec = deref(item_spec)
                 more_properties = collapsed_properties(item_spec, swagger_spec)
                 properties.update(more_properties)
-        swagger_spec.cache[i] = properties
+        swagger_spec.cache_schema[i] = properties
         return properties

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -190,7 +190,7 @@ def handle_null_value(swagger_spec, schema_object_spec):
     raise SwaggerMappingError(
         'Spec {0} is a required value'.format(schema_object_spec))
 
-#@clru_cache(maxsize=325, typed=False)
+@clru_cache(maxsize=325, typed=False)
 def collapsed_properties(model_spec, swagger_spec):
     """Processes model spec and outputs dictionary with attributes
     as the keys and attribute spec as the value for the model.

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -216,5 +216,4 @@ def collapsed_properties(model_spec, swagger_spec):
             more_properties = collapsed_properties(item_spec, swagger_spec)
             properties.update(more_properties)
 
-    print(properties)
-    return properties
+    return frozendict(properties)

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -150,9 +150,8 @@ def get_spec_for_prop(swagger_spec, object_spec, object_value, prop_name, proper
         if 'x-nullable' in prop_spec and 'x-nullable' not in result_spec:
             result_spec = copy.deepcopy(result_spec)
             result_spec['x-nullable'] = prop_spec['x-nullable']
-        if not is_frozendict_like(result_spec):
-            return transform_dict_to_frozendict(result_spec)
-        return result_spec
+        return transform_dict_to_frozendict(result_spec)
+        #return result_spec
 
     additional_props = deref(object_spec).get('additionalProperties', True)
 

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -98,9 +98,9 @@ def get_spec_for_prop(swagger_spec, object_spec, object_value, prop_name, proper
 
     i = id(prop_name)
     try:
-        return cache[i]
+        return swagger_spec.cache[i]
     except KeyError:
-        deref = swagger_spec.deref
+        deref = swagger_spec.fast_deref
 
         if properties is None:
             properties = collapsed_properties(deref(object_spec), swagger_spec)
@@ -117,7 +117,7 @@ def get_spec_for_prop(swagger_spec, object_spec, object_value, prop_name, proper
                 result_spec = copy.deepcopy(result_spec)
                 result_spec['x-nullable'] = prop_spec['x-nullable']
 
-            cache[i] = result_spec
+            swagger_spec.cache[i] = result_spec
             return result_spec
 
         additional_props = deref(object_spec).get('additionalProperties', True)
@@ -125,13 +125,13 @@ def get_spec_for_prop(swagger_spec, object_spec, object_value, prop_name, proper
         if isinstance(additional_props, bool):
         # no spec for additional properties to conform to - this is basically
         # a way to send pretty much anything across the wire as is.
-            cache[i] = None
+            swagger_spec.cache[i] = None
             return None
 
         additional_props = deref(additional_props)
         if is_dict_like(additional_props):
         # spec that all additional props MUST conform to
-            cache[i] = additional_props
+            swagger_spec.cache[i] = additional_props
             return additional_props
 
         raise SwaggerMappingError(
@@ -174,7 +174,7 @@ def collapsed_properties(model_spec, swagger_spec):
 
     i = id(model_spec)
     try:
-        return cache[i]
+        return swagger_spec.cache[i]
     except KeyError:
         #print(model_spec)
         properties = {}
@@ -191,5 +191,5 @@ def collapsed_properties(model_spec, swagger_spec):
                 item_spec = deref(item_spec)
                 more_properties = collapsed_properties(item_spec, swagger_spec)
                 properties.update(more_properties)
-        cache[i] = properties
+        swagger_spec.cache[i] = properties
         return properties

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -84,7 +84,7 @@ def is_frozendict_like(spec):
     return isinstance(spec, frozendict)
 
 def transform_dict_to_frozendict(spec):
-    #print(spec)
+    print('ttt')
     for key, value in iteritems(spec):
         if is_list_like(value):
             spec[key] = transfer_list_to_tuple(value)

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -139,7 +139,6 @@ def get_spec_for_prop(swagger_spec, object_spec, object_value, prop_name, proper
     prop_spec = properties.get(prop_name)
 
     if prop_spec is not None:
-        print(prop_spec)
         result_spec = deref(prop_spec)
         # If the de-referenced specification is for a x-nullable property
         # then copy the spec and add the x-nullable property.

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -149,12 +149,8 @@ def get_spec_for_prop(swagger_spec, object_spec, object_value, prop_name, proper
         if 'x-nullable' in prop_spec and 'x-nullable' not in result_spec:
             result_spec = copy.deepcopy(result_spec)
             result_spec['x-nullable'] = prop_spec['x-nullable']
-        if is_frozendict_like(result_spec):
-            return result_spec
-        else:
-            print('2222')
-            return transform_dict_to_frozendict(result_spec)
-        #return result_spec
+        
+        return result_spec
 
     additional_props = deref(object_spec).get('additionalProperties', True)
 

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -150,7 +150,10 @@ def get_spec_for_prop(swagger_spec, object_spec, object_value, prop_name, proper
         if 'x-nullable' in prop_spec and 'x-nullable' not in result_spec:
             result_spec = copy.deepcopy(result_spec)
             result_spec['x-nullable'] = prop_spec['x-nullable']
-        return transform_dict_to_frozendict(result_spec)
+        if is_frozendict_like(result_spec):
+            return result_spec
+        else:
+            return transform_dict_to_frozendict(result_spec)
         #return result_spec
 
     additional_props = deref(object_spec).get('additionalProperties', True)

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -133,7 +133,7 @@ def get_spec_for_prop(swagger_spec, object_spec, object_value, prop_name, proper
     :return: spec for the given property or None if no spec found
     :rtype: dict or None
     """
-    deref = swagger_spec.fast_deref
+    deref = swagger_spec.deref
 
     if properties is None:
         properties = collapsed_properties(deref(object_spec), swagger_spec)
@@ -141,7 +141,7 @@ def get_spec_for_prop(swagger_spec, object_spec, object_value, prop_name, proper
     #print(prop_spec)
 
     if prop_spec is not None:
-        result_spec = deref(prop_spec)
+        result_spec = frozendict(deref(prop_spec))
         # If the de-referenced specification is for a x-nullable property
         # then copy the spec and add the x-nullable property.
         # If in the future there are other attributes on the property that
@@ -150,11 +150,11 @@ def get_spec_for_prop(swagger_spec, object_spec, object_value, prop_name, proper
         if 'x-nullable' in prop_spec and 'x-nullable' not in result_spec:
             result_spec = copy.deepcopy(result_spec)
             result_spec['x-nullable'] = prop_spec['x-nullable']
-        if is_frozendict_like(result_spec):
-            return result_spec
-        else:
-            print('ttt')
-            return transform_dict_to_frozendict(result_spec)
+        #if is_frozendict_like(result_spec):
+        return result_spec
+        #else:
+        #    print('ttt')
+        #    return transform_dict_to_frozendict(result_spec)
         #return result_spec
 
     additional_props = deref(object_spec).get('additionalProperties', True)

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -203,6 +203,7 @@ def collapsed_properties(model_spec, swagger_spec):
     :param swagger_spec: :class:`bravado_core.spec.Spec`
     :returns: dict
     """
+    print('jjj')
 
     properties = {}
 

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -200,6 +200,7 @@ def collapsed_properties(model_spec, swagger_spec):
     :param swagger_spec: :class:`bravado_core.spec.Spec`
     :returns: dict
     """
+    print(model_spec)
 
     properties = {}
 

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -206,6 +206,7 @@ def collapsed_properties(model_spec, swagger_spec):
     try:
         return cache[i]
     except KeyError:
+        print('1')
         properties = {}
 
     # properties may or may not be present

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -96,47 +96,47 @@ def get_spec_for_prop(swagger_spec, object_spec, object_value, prop_name, proper
     :rtype: dict or None
     """
 
-    #i = id(prop_name)
-    #try:
-    #    return cache[i]
-    #except KeyError:
-    deref = swagger_spec.deref
+    i = id(prop_name)
+    try:
+        return cache[i]
+    except KeyError:
+        deref = swagger_spec.fast_deref
 
-    if properties is None:
-        properties = collapsed_properties(deref(object_spec), swagger_spec)
-    prop_spec = properties.get(prop_name)
+        if properties is None:
+            properties = collapsed_properties(deref(object_spec), swagger_spec)
+        prop_spec = properties.get(prop_name)
 
-    if prop_spec is not None:
-        result_spec = deref(prop_spec)
+        if prop_spec is not None:
+            result_spec = deref(prop_spec)
         # If the de-referenced specification is for a x-nullable property
         # then copy the spec and add the x-nullable property.
         # If in the future there are other attributes on the property that
         # modify a referenced schema, it can be done here (or rewrite
         # unmarshal to pass the unreferenced property spec as another arg).
-        if 'x-nullable' in prop_spec and 'x-nullable' not in result_spec:
-            result_spec = copy.deepcopy(result_spec)
-            result_spec['x-nullable'] = prop_spec['x-nullable']
+            if 'x-nullable' in prop_spec and 'x-nullable' not in result_spec:
+                result_spec = copy.deepcopy(result_spec)
+                result_spec['x-nullable'] = prop_spec['x-nullable']
 
-            #cache[i] = result_spec
-        return result_spec
+            cache[i] = result_spec
+            return result_spec
 
-    additional_props = deref(object_spec).get('additionalProperties', True)
+        additional_props = deref(object_spec).get('additionalProperties', True)
 
-    if isinstance(additional_props, bool):
+        if isinstance(additional_props, bool):
         # no spec for additional properties to conform to - this is basically
         # a way to send pretty much anything across the wire as is.
-        cache[i] = None
-        return None
+            cache[i] = None
+            return None
 
-    additional_props = deref(additional_props)
-    if is_dict_like(additional_props):
+        additional_props = deref(additional_props)
+        if is_dict_like(additional_props):
         # spec that all additional props MUST conform to
-        cache[i] = additional_props
-        return additional_props
+            cache[i] = additional_props
+            return additional_props
 
-    raise SwaggerMappingError(
-        "Don't know what to do with `additionalProperties` in spec {0} "
-        "when inspecting value {1}".format(object_spec, object_value))
+        raise SwaggerMappingError(
+            "Don't know what to do with `additionalProperties` in spec {0} "
+            "when inspecting value {1}".format(object_spec, object_value))
 
 
 def handle_null_value(swagger_spec, schema_object_spec):

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -118,7 +118,7 @@ def is_list_like(spec):
     return isinstance(spec, (list, tuple))
 
 @lru_cache(maxsize=100)
-def get_spec_for_prop(swagger_spec, object_spec, object_value, prop_name, properties=None):
+def get_spec_for_prop(swagger_spec, object_spec, prop_name, properties=None):
     """Given a jsonschema object spec and value, retrieve the spec for the
      given property taking 'additionalProperties' into consideration.
 
@@ -169,9 +169,9 @@ def get_spec_for_prop(swagger_spec, object_spec, object_value, prop_name, proper
         # spec that all additional props MUST conform to
         return additional_props
 
-    raise SwaggerMappingError(
-        "Don't know what to do with `additionalProperties` in spec {0} "
-        "when inspecting value {1}".format(object_spec, object_value))
+    #raise SwaggerMappingError(
+    #    "Don't know what to do with `additionalProperties` in spec {0} "
+    #    "when inspecting value {1}".format(object_spec, object_value))
 
 
 def handle_null_value(swagger_spec, schema_object_spec):

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -81,6 +81,7 @@ def is_dict_like(spec):
     return isinstance(spec, (dict, Mapping))
 
 def is_frozendict_like(spec):
+    print('rrr')
     return isinstance(spec, frozendict)
 
 def transform_dict_to_frozendict(spec):
@@ -149,7 +150,7 @@ def get_spec_for_prop(swagger_spec, object_spec, object_value, prop_name, proper
         if 'x-nullable' in prop_spec and 'x-nullable' not in result_spec:
             result_spec = copy.deepcopy(result_spec)
             result_spec['x-nullable'] = prop_spec['x-nullable']
-        
+
         return result_spec
 
     additional_props = deref(object_spec).get('additionalProperties', True)

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -177,7 +177,7 @@ def collapsed_properties(model_spec, swagger_spec):
 
     # allOf may or may not be present
         if 'allOf' in model_spec:
-            deref = swagger_spec.fast_deref
+            deref = swagger_spec.deref
             for item_spec in model_spec['allOf']:
                 item_spec = deref(item_spec)
                 more_properties = collapsed_properties(item_spec, swagger_spec)

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -206,7 +206,6 @@ def collapsed_properties(model_spec, swagger_spec):
     try:
         return cache[i]
     except KeyError:
-        print('1')
         properties = {}
 
     # properties may or may not be present

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -166,10 +166,9 @@ def collapsed_properties(model_spec, swagger_spec):
 
     i = id(model_spec)
     try:
-        print('1')
-        return cache[id]
+        return cache[i]
     except KeyError:
-        #print(model_spec)
+        print(model_spec)
         properties = {}
 
     # properties may or may not be present

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -137,7 +137,6 @@ def get_spec_for_prop(swagger_spec, object_spec, object_value, prop_name, proper
     if properties is None:
         properties = collapsed_properties(deref(object_spec), swagger_spec)
     prop_spec = properties.get(prop_name)
-    print(prop_name)
 
     if prop_spec is not None:
         result_spec = deref(prop_spec)

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -84,6 +84,7 @@ def is_frozendict_like(spec):
     return isinstance(spec, frozendict)
 
 def transform_dict_to_frozendict(spec):
+    print('lllll')
     for key, value in iteritems(spec):
         if is_list_like(value):
             spec[key] = transfer_list_to_tuple(value)

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -100,7 +100,7 @@ def get_spec_for_prop(swagger_spec, object_spec, object_value, prop_name, proper
     try:
         return cache[i]
     except KeyError:
-        deref = swagger_spec.fast_deref
+        deref = swagger_spec.deref
 
         if properties is None:
             properties = collapsed_properties(deref(object_spec), swagger_spec)
@@ -117,7 +117,7 @@ def get_spec_for_prop(swagger_spec, object_spec, object_value, prop_name, proper
                 result_spec = copy.deepcopy(result_spec)
                 result_spec['x-nullable'] = prop_spec['x-nullable']
 
-            cache[i] = result_spec
+            #cache[i] = result_spec
             return result_spec
 
         additional_props = deref(object_spec).get('additionalProperties', True)

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -149,6 +149,7 @@ def get_spec_for_prop(swagger_spec, object_spec, object_value, prop_name, proper
         if 'x-nullable' in prop_spec and 'x-nullable' not in result_spec:
             result_spec = copy.deepcopy(result_spec)
             result_spec['x-nullable'] = prop_spec['x-nullable']
+        print(result_spec)
         return result_spec
 
     additional_props = deref(object_spec).get('additionalProperties', True)

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -132,7 +132,7 @@ def get_spec_for_prop(swagger_spec, object_spec, object_value, prop_name, proper
     :return: spec for the given property or None if no spec found
     :rtype: dict or None
     """
-    deref = swagger_spec.deref
+    deref = swagger_spec.fast_deref
 
     if properties is None:
         properties = collapsed_properties(deref(object_spec), swagger_spec)
@@ -149,6 +149,8 @@ def get_spec_for_prop(swagger_spec, object_spec, object_value, prop_name, proper
         if 'x-nullable' in prop_spec and 'x-nullable' not in result_spec:
             result_spec = copy.deepcopy(result_spec)
             result_spec['x-nullable'] = prop_spec['x-nullable']
+        if is_dict_like(result_spec):
+            result_spec = transform_dict_to_frozendict(result_spec)
         return result_spec
 
     additional_props = deref(object_spec).get('additionalProperties', True)

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -96,47 +96,47 @@ def get_spec_for_prop(swagger_spec, object_spec, object_value, prop_name, proper
     :rtype: dict or None
     """
 
-    i = id(prop_name)
-    try:
-        return cache[i]
-    except KeyError:
-        deref = swagger_spec.deref
+    #i = id(prop_name)
+    #try:
+    #    return cache[i]
+    #except KeyError:
+    deref = swagger_spec.deref
 
-        if properties is None:
-            properties = collapsed_properties(deref(object_spec), swagger_spec)
-        prop_spec = properties.get(prop_name)
+    if properties is None:
+        properties = collapsed_properties(deref(object_spec), swagger_spec)
+    prop_spec = properties.get(prop_name)
 
-        if prop_spec is not None:
-            result_spec = deref(prop_spec)
+    if prop_spec is not None:
+        result_spec = deref(prop_spec)
         # If the de-referenced specification is for a x-nullable property
         # then copy the spec and add the x-nullable property.
         # If in the future there are other attributes on the property that
         # modify a referenced schema, it can be done here (or rewrite
         # unmarshal to pass the unreferenced property spec as another arg).
-            if 'x-nullable' in prop_spec and 'x-nullable' not in result_spec:
-                result_spec = copy.deepcopy(result_spec)
-                result_spec['x-nullable'] = prop_spec['x-nullable']
+        if 'x-nullable' in prop_spec and 'x-nullable' not in result_spec:
+            result_spec = copy.deepcopy(result_spec)
+            result_spec['x-nullable'] = prop_spec['x-nullable']
 
             #cache[i] = result_spec
-            return result_spec
+        return result_spec
 
-        additional_props = deref(object_spec).get('additionalProperties', True)
+    additional_props = deref(object_spec).get('additionalProperties', True)
 
-        if isinstance(additional_props, bool):
+    if isinstance(additional_props, bool):
         # no spec for additional properties to conform to - this is basically
         # a way to send pretty much anything across the wire as is.
-            cache[i] = None
-            return None
+        cache[i] = None
+        return None
 
-        additional_props = deref(additional_props)
-        if is_dict_like(additional_props):
+    additional_props = deref(additional_props)
+    if is_dict_like(additional_props):
         # spec that all additional props MUST conform to
-            cache[i] = additional_props
-            return additional_props
+        cache[i] = additional_props
+        return additional_props
 
-        raise SwaggerMappingError(
-            "Don't know what to do with `additionalProperties` in spec {0} "
-            "when inspecting value {1}".format(object_spec, object_value))
+    raise SwaggerMappingError(
+        "Don't know what to do with `additionalProperties` in spec {0} "
+        "when inspecting value {1}".format(object_spec, object_value))
 
 
 def handle_null_value(swagger_spec, schema_object_spec):

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -200,7 +200,6 @@ def collapsed_properties(model_spec, swagger_spec):
     :param swagger_spec: :class:`bravado_core.spec.Spec`
     :returns: dict
     """
-    print(model_spec)
 
     properties = {}
 
@@ -217,4 +216,5 @@ def collapsed_properties(model_spec, swagger_spec):
             more_properties = collapsed_properties(item_spec, swagger_spec)
             properties.update(more_properties)
 
+    print(properties)
     return properties

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -84,7 +84,6 @@ def is_frozendict_like(spec):
     return isinstance(spec, frozendict)
 
 def transform_dict_to_frozendict(spec):
-    print('ttt')
     for key, value in iteritems(spec):
         if is_list_like(value):
             spec[key] = transfer_list_to_tuple(value)

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -136,8 +136,8 @@ def get_spec_for_prop(swagger_spec, object_spec, object_value, prop_name, proper
 
     if properties is None:
         properties = collapsed_properties(deref(object_spec), swagger_spec)
-        print(properties)
     prop_spec = properties.get(prop_name)
+    print(prop_spec)
 
     if prop_spec is not None:
         result_spec = deref(prop_spec)

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -138,6 +138,7 @@ def get_spec_for_prop(swagger_spec, object_spec, object_value, prop_name, proper
     if properties is None:
         properties = collapsed_properties(deref(object_spec), swagger_spec)
     prop_spec = properties.get(prop_name)
+    print(prop_spec)
 
     if prop_spec is not None:
         result_spec = deref(prop_spec)
@@ -149,7 +150,6 @@ def get_spec_for_prop(swagger_spec, object_spec, object_value, prop_name, proper
         if 'x-nullable' in prop_spec and 'x-nullable' not in result_spec:
             result_spec = copy.deepcopy(result_spec)
             result_spec['x-nullable'] = prop_spec['x-nullable']
-        print(result_spec)
         return result_spec
 
     additional_props = deref(object_spec).get('additionalProperties', True)

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -208,6 +208,7 @@ def collapsed_properties(model_spec, swagger_spec):
     """
 
     properties = {}
+    print('ttt')
 
     # properties may or may not be present
     if 'properties' in model_spec:

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -220,4 +220,4 @@ def collapsed_properties(model_spec, swagger_spec):
             more_properties = collapsed_properties(item_spec, swagger_spec)
             properties.update(more_properties)
 
-    return frozendict(properties)
+    return properties

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -137,7 +137,7 @@ def get_spec_for_prop(swagger_spec, object_spec, object_value, prop_name, proper
     if properties is None:
         properties = collapsed_properties(deref(object_spec), swagger_spec)
     prop_spec = properties.get(prop_name)
-    print(prop_name)
+    print(properties)
 
     if prop_spec is not None:
         result_spec = deref(prop_spec)

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -138,7 +138,7 @@ def get_spec_for_prop(swagger_spec, object_spec, object_value, prop_name, proper
     if properties is None:
         properties = collapsed_properties(deref(object_spec), swagger_spec)
     prop_spec = properties.get(prop_name)
-    print(prop_spec)
+    #print(prop_spec)
 
     if prop_spec is not None:
         result_spec = deref(prop_spec)

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -203,7 +203,6 @@ def collapsed_properties(model_spec, swagger_spec):
     :param swagger_spec: :class:`bravado_core.spec.Spec`
     :returns: dict
     """
-    print('jjj')
 
     properties = {}
 

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -133,7 +133,7 @@ def get_spec_for_prop(swagger_spec, object_spec, object_value, prop_name, proper
     :return: spec for the given property or None if no spec found
     :rtype: dict or None
     """
-    deref = swagger_spec.deref
+    deref = swagger_spec.fast_deref
 
     if properties is None:
         properties = collapsed_properties(deref(object_spec), swagger_spec)
@@ -141,7 +141,7 @@ def get_spec_for_prop(swagger_spec, object_spec, object_value, prop_name, proper
     #print(prop_spec)
 
     if prop_spec is not None:
-        result_spec = frozendict(deref(prop_spec))
+        result_spec = deref(prop_spec)
         # If the de-referenced specification is for a x-nullable property
         # then copy the spec and add the x-nullable property.
         # If in the future there are other attributes on the property that
@@ -150,11 +150,10 @@ def get_spec_for_prop(swagger_spec, object_spec, object_value, prop_name, proper
         if 'x-nullable' in prop_spec and 'x-nullable' not in result_spec:
             result_spec = copy.deepcopy(result_spec)
             result_spec['x-nullable'] = prop_spec['x-nullable']
-        #if is_frozendict_like(result_spec):
-        return result_spec
-        #else:
-        #    print('ttt')
-        #    return transform_dict_to_frozendict(result_spec)
+        if is_frozendict_like(result_spec):
+            return result_spec
+        else:
+            return transform_dict_to_frozendict(result_spec)
         #return result_spec
 
     additional_props = deref(object_spec).get('additionalProperties', True)

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -117,8 +117,8 @@ def is_list_like(spec):
     """
     return isinstance(spec, (list, tuple))
 
-@lru_cache(maxsize=100)
-def get_spec_for_prop(swagger_spec, object_spec, prop_name, properties=None):
+
+def get_spec_for_prop(swagger_spec, object_spec, object_value, prop_name, properties=None):
     """Given a jsonschema object spec and value, retrieve the spec for the
      given property taking 'additionalProperties' into consideration.
 
@@ -169,9 +169,9 @@ def get_spec_for_prop(swagger_spec, object_spec, prop_name, properties=None):
         # spec that all additional props MUST conform to
         return additional_props
 
-    #raise SwaggerMappingError(
-    #    "Don't know what to do with `additionalProperties` in spec {0} "
-    #    "when inspecting value {1}".format(object_spec, object_value))
+    raise SwaggerMappingError(
+        "Don't know what to do with `additionalProperties` in spec {0} "
+        "when inspecting value {1}".format(object_spec, object_value))
 
 
 def handle_null_value(swagger_spec, schema_object_spec):
@@ -223,4 +223,4 @@ def collapsed_properties(model_spec, swagger_spec):
             more_properties = collapsed_properties(item_spec, swagger_spec)
             properties.update(more_properties)
 
-    return frozendict(properties)
+    return properties

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -153,6 +153,7 @@ def get_spec_for_prop(swagger_spec, object_spec, object_value, prop_name, proper
         if is_frozendict_like(result_spec):
             return result_spec
         else:
+            print('ttt')
             return transform_dict_to_frozendict(result_spec)
         #return result_spec
 

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -207,6 +207,7 @@ def collapsed_properties(model_spec, swagger_spec):
     if 'properties' in model_spec:
         for attr, attr_spec in iteritems(model_spec['properties']):
             properties[attr] = attr_spec
+            print(attr_spec)
 
     # allOf may or may not be present
     if 'allOf' in model_spec:

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -150,7 +150,6 @@ def get_spec_for_prop(swagger_spec, object_spec, object_value, prop_name, proper
             result_spec = copy.deepcopy(result_spec)
             result_spec['x-nullable'] = prop_spec['x-nullable']
         if is_frozendict_like(result_spec):
-            print('1111')
             return result_spec
         else:
             print('2222')

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -207,7 +207,6 @@ def collapsed_properties(model_spec, swagger_spec):
     """
 
     properties = {}
-    print(model_spec)
 
     # properties may or may not be present
     if 'properties' in model_spec:

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -216,7 +216,7 @@ def collapsed_properties(model_spec, swagger_spec):
 
     # allOf may or may not be present
     if 'allOf' in model_spec:
-        deref = swagger_spec.deref
+        deref = swagger_spec.fast_deref
         for item_spec in model_spec['allOf']:
             item_spec = deref(item_spec)
             more_properties = collapsed_properties(item_spec, swagger_spec)

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -95,7 +95,7 @@ def get_spec_for_prop(swagger_spec, object_spec, object_value, prop_name, proper
     :return: spec for the given property or None if no spec found
     :rtype: dict or None
     """
-    deref = swagger_spec.fast_deref
+    deref = swagger_spec.deref
 
     if properties is None:
         properties = collapsed_properties(deref(object_spec), swagger_spec)

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -100,6 +100,7 @@ def get_spec_for_prop(swagger_spec, object_spec, object_value, prop_name, proper
     if properties is None:
         properties = collapsed_properties(deref(object_spec), swagger_spec)
     prop_spec = properties.get(prop_name)
+    print(prop_name)
 
     if prop_spec is not None:
         result_spec = deref(prop_spec)

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -166,7 +166,7 @@ def collapsed_properties(model_spec, swagger_spec):
 
     i = id(model_spec)
     try:
-        return swagger_spec.cache[id]
+        return cache[id]
     except KeyError:
         properties = {}
 
@@ -182,5 +182,5 @@ def collapsed_properties(model_spec, swagger_spec):
                 item_spec = deref(item_spec)
                 more_properties = collapsed_properties(item_spec, swagger_spec)
                 properties.update(more_properties)
-        swagger_spec.cache[i] = properties
+        cache[i] = properties
         return properties

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -209,8 +209,6 @@ def collapsed_properties(model_spec, swagger_spec):
     # properties may or may not be present
     if 'properties' in model_spec:
         for attr, attr_spec in iteritems(model_spec['properties']):
-            if is_dict_like(attr_spec):
-                attr_spec = transform_dict_to_frozendict(attr_spec)
             properties[attr] = attr_spec
 
     # allOf may or may not be present

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -137,7 +137,6 @@ def get_spec_for_prop(swagger_spec, object_spec, object_value, prop_name, proper
     if properties is None:
         properties = collapsed_properties(deref(object_spec), swagger_spec)
     prop_spec = properties.get(prop_name)
-    print(properties)
 
     if prop_spec is not None:
         result_spec = deref(prop_spec)

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -84,7 +84,7 @@ def is_frozendict_like(spec):
     return isinstance(spec, frozendict)
 
 def transform_dict_to_frozendict(spec):
-    #print(spec)
+    print(spec)
     for key, value in iteritems(spec):
         if is_list_like(value):
             spec[key] = transfer_list_to_tuple(value)

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -100,8 +100,6 @@ def get_spec_for_prop(swagger_spec, object_spec, object_value, prop_name, proper
     if properties is None:
         properties = collapsed_properties(deref(object_spec), swagger_spec)
     prop_spec = properties.get(prop_name)
-    print(prop_name)
-    print(prop_spec)
 
     if prop_spec is not None:
         result_spec = deref(prop_spec)
@@ -116,6 +114,7 @@ def get_spec_for_prop(swagger_spec, object_spec, object_value, prop_name, proper
 
         return result_spec
 
+    print('tttttttttt')
     additional_props = deref(object_spec).get('additionalProperties', True)
 
     if isinstance(additional_props, bool):

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -16,7 +16,7 @@ SWAGGER_PRIMITIVES = (
     'boolean',
     'null',
 )
-#cache = {}
+
 
 def has_default(swagger_spec, schema_object_spec):
     return 'default' in swagger_spec.deref(schema_object_spec)
@@ -48,11 +48,9 @@ def is_prop_nullable(swagger_spec, schema_object_spec):
 
 def is_ref(spec):
     """ Check if the given spec is a Mapping and contains a $ref.
-
     FYI: This function gets called A LOT during unmarshalling and is_dict_like
     adds a bunch of extra time. It is faster to use a try/except than it is
     to call is_dict_like first for every spec input.
-
     :param spec: swagger object specification
     :rtype: boolean
     """
@@ -60,6 +58,7 @@ def is_ref(spec):
         return '$ref' in spec and is_dict_like(spec)
     except TypeError:
         return False
+
 
 def is_dict_like(spec):
     """
@@ -72,6 +71,7 @@ def is_dict_like(spec):
     # expensive isinstance(spec, Mapping) check.
     return isinstance(spec, (dict, Mapping))
 
+
 def is_list_like(spec):
     """
     :param spec: swagger object specification in dict form
@@ -83,7 +83,6 @@ def is_list_like(spec):
 def get_spec_for_prop(swagger_spec, object_spec, object_value, prop_name, properties=None):
     """Given a jsonschema object spec and value, retrieve the spec for the
      given property taking 'additionalProperties' into consideration.
-
     :param swagger_spec: Spec object
     :type swagger_spec: bravado_core.spec.Spec
     :param object_spec: spec for a jsonschema 'object' in dict form
@@ -91,59 +90,48 @@ def get_spec_for_prop(swagger_spec, object_spec, object_value, prop_name, proper
         used in error message.
     :param prop_name: name of the property to retrieve the spec for
     :param properties: collapsed properties of the object
-
     :return: spec for the given property or None if no spec found
     :rtype: dict or None
     """
+    deref = swagger_spec.deref
 
-    i = id(prop_name)
-    try:
-        return swagger_spec.cache_schema[i]
-    except KeyError:
-        deref = swagger_spec.fast_deref
+    if properties is None:
+        properties = fast_collapsed_properties(deref(object_spec), swagger_spec)
+    prop_spec = properties.get(prop_name)
 
-        if properties is None:
-            properties = collapsed_properties(deref(object_spec), swagger_spec)
-        prop_spec = properties.get(prop_name)
-
-        if prop_spec is not None:
-            result_spec = deref(prop_spec)
+    if prop_spec is not None:
+        result_spec = deref(prop_spec)
         # If the de-referenced specification is for a x-nullable property
         # then copy the spec and add the x-nullable property.
         # If in the future there are other attributes on the property that
         # modify a referenced schema, it can be done here (or rewrite
         # unmarshal to pass the unreferenced property spec as another arg).
-            if 'x-nullable' in prop_spec and 'x-nullable' not in result_spec:
-                result_spec = copy.deepcopy(result_spec)
-                result_spec['x-nullable'] = prop_spec['x-nullable']
+        if 'x-nullable' in prop_spec and 'x-nullable' not in result_spec:
+            result_spec = copy.deepcopy(result_spec)
+            result_spec['x-nullable'] = prop_spec['x-nullable']
+        return result_spec
 
-            swagger_spec.cache_schema[i] = result_spec
-            return result_spec
+    additional_props = deref(object_spec).get('additionalProperties', True)
 
-        additional_props = deref(object_spec).get('additionalProperties', True)
-
-        if isinstance(additional_props, bool):
+    if isinstance(additional_props, bool):
         # no spec for additional properties to conform to - this is basically
         # a way to send pretty much anything across the wire as is.
-            swagger_spec.cache_schema[i] = None
-            return None
+        return None
 
-        additional_props = deref(additional_props)
-        if is_dict_like(additional_props):
+    additional_props = deref(additional_props)
+    if is_dict_like(additional_props):
         # spec that all additional props MUST conform to
-            swagger_spec.cache_schema[i] = additional_props
-            return additional_props
+        return additional_props
 
-        raise SwaggerMappingError(
-            "Don't know what to do with `additionalProperties` in spec {0} "
-            "when inspecting value {1}".format(object_spec, object_value))
+    raise SwaggerMappingError(
+        "Don't know what to do with `additionalProperties` in spec {0} "
+        "when inspecting value {1}".format(object_spec, object_value))
 
 
 def handle_null_value(swagger_spec, schema_object_spec):
     """Handle a null value for the associated schema object spec. Checks the
      x-nullable attribute in the spec to see if it is allowed and returns None
      if so and raises an exception otherwise.
-
     :param swagger_spec: Spec object
     :type swagger_spec: bravado_core.spec.Spec
     :param schema_object_spec: dict
@@ -159,13 +147,41 @@ def handle_null_value(swagger_spec, schema_object_spec):
     raise SwaggerMappingError(
         'Spec {0} is a required value'.format(schema_object_spec))
 
+
 def collapsed_properties(model_spec, swagger_spec):
     """Processes model spec and outputs dictionary with attributes
     as the keys and attribute spec as the value for the model.
-
     This handles traversing any polymorphic models and the hierarchy
     of properties properly.
+    :param model_spec: model specification (must be dereferenced already)
+    :type model_spec: dict
+    :param swagger_spec: :class:`bravado_core.spec.Spec`
+    :returns: dict
+    """
 
+    properties = {}
+
+    # properties may or may not be present
+    if 'properties' in model_spec:
+        for attr, attr_spec in iteritems(model_spec['properties']):
+            properties[attr] = attr_spec
+
+    # allOf may or may not be present
+    if 'allOf' in model_spec:
+        deref = swagger_spec.deref
+        for item_spec in model_spec['allOf']:
+            item_spec = deref(item_spec)
+            more_properties = collapsed_properties(item_spec, swagger_spec)
+            properties.update(more_properties)
+
+    return properties
+
+
+def fast_collapsed_properties(model_spec, swagger_spec):
+    """Processes model spec and outputs dictionary with attributes
+    as the keys and attribute spec as the value for the model.
+    This handles traversing any polymorphic models and the hierarchy
+    of properties properly.
     :param model_spec: model specification (must be dereferenced already)
     :type model_spec: dict
     :param swagger_spec: :class:`bravado_core.spec.Spec`
@@ -176,7 +192,6 @@ def collapsed_properties(model_spec, swagger_spec):
     try:
         return swagger_spec.cache_schema[i]
     except KeyError:
-        #print(model_spec)
         properties = {}
 
     # properties may or may not be present
@@ -189,7 +204,8 @@ def collapsed_properties(model_spec, swagger_spec):
             deref = swagger_spec.deref
             for item_spec in model_spec['allOf']:
                 item_spec = deref(item_spec)
-                more_properties = collapsed_properties(item_spec, swagger_spec)
+                more_properties = fast_collapsed_properties(item_spec, swagger_spec)
                 properties.update(more_properties)
-        swagger_spec.cache_schema[i] = properties
+            swagger_spec.cache_schema[i] = properties
+
         return properties

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -150,8 +150,6 @@ def get_spec_for_prop(swagger_spec, object_spec, object_value, prop_name, proper
         if 'x-nullable' in prop_spec and 'x-nullable' not in result_spec:
             result_spec = copy.deepcopy(result_spec)
             result_spec['x-nullable'] = prop_spec['x-nullable']
-        if is_dict_like(result_spec):
-            result_spec = transform_dict_to_frozendict(result_spec)
         return result_spec
 
     additional_props = deref(object_spec).get('additionalProperties', True)

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -150,8 +150,10 @@ def get_spec_for_prop(swagger_spec, object_spec, object_value, prop_name, proper
             result_spec = copy.deepcopy(result_spec)
             result_spec['x-nullable'] = prop_spec['x-nullable']
         if is_frozendict_like(result_spec):
+            print('1111')
             return result_spec
         else:
+            print('2222')
             return transform_dict_to_frozendict(result_spec)
         #return result_spec
 

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -18,7 +18,7 @@ SWAGGER_PRIMITIVES = (
     'boolean',
     'null',
 )
-
+cache = {}
 
 def has_default(swagger_spec, schema_object_spec):
     return 'default' in swagger_spec.deref(schema_object_spec)
@@ -81,7 +81,6 @@ def is_dict_like(spec):
     return isinstance(spec, (dict, Mapping))
 
 def is_frozendict_like(spec):
-    print('rrr')
     return isinstance(spec, frozendict)
 
 def transform_dict_to_frozendict(spec):
@@ -190,7 +189,7 @@ def handle_null_value(swagger_spec, schema_object_spec):
     raise SwaggerMappingError(
         'Spec {0} is a required value'.format(schema_object_spec))
 
-@lru_cache(maxsize=10)
+#@lru_cache(maxsize=10)
 def collapsed_properties(model_spec, swagger_spec):
     """Processes model spec and outputs dictionary with attributes
     as the keys and attribute spec as the value for the model.
@@ -203,20 +202,24 @@ def collapsed_properties(model_spec, swagger_spec):
     :param swagger_spec: :class:`bravado_core.spec.Spec`
     :returns: dict
     """
-
-    properties = {}
+    i = id(model_spec)
+    try:
+        return cache[i]
+    except KeyError:
+        properties = {}
 
     # properties may or may not be present
-    if 'properties' in model_spec:
-        for attr, attr_spec in iteritems(model_spec['properties']):
-            properties[attr] = attr_spec
+        if 'properties' in model_spec:
+            for attr, attr_spec in iteritems(model_spec['properties']):
+                properties[attr] = attr_spec
 
     # allOf may or may not be present
-    if 'allOf' in model_spec:
-        deref = swagger_spec.fast_deref
-        for item_spec in model_spec['allOf']:
-            item_spec = deref(item_spec)
-            more_properties = collapsed_properties(item_spec, swagger_spec)
-            properties.update(more_properties)
+        if 'allOf' in model_spec:
+            deref = swagger_spec.fast_deref
+            for item_spec in model_spec['allOf']:
+                item_spec = deref(item_spec)
+                more_properties = collapsed_properties(item_spec, swagger_spec)
+                properties.update(more_properties)
 
-    return properties
+        cache[i] = properties
+        return properties

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -6,7 +6,7 @@ from six import iteritems
 
 from bravado_core.exception import SwaggerMappingError
 from frozendict import frozendict
-from fastcache import clru_cache
+from functools import lru_cache
 
 
 # 'object' and 'array' are omitted since this should really be read as
@@ -194,7 +194,7 @@ def handle_null_value(swagger_spec, schema_object_spec):
     raise SwaggerMappingError(
         'Spec {0} is a required value'.format(schema_object_spec))
 
-@clru_cache(maxsize=100, typed=False)
+@lru_cache(maxsize=100)
 def collapsed_properties(model_spec, swagger_spec):
     """Processes model spec and outputs dictionary with attributes
     as the keys and attribute spec as the value for the model.

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -166,9 +166,10 @@ def collapsed_properties(model_spec, swagger_spec):
 
     i = id(model_spec)
     try:
+        print('1')
         return cache[id]
     except KeyError:
-        print(model_spec)
+        #print(model_spec)
         properties = {}
 
     # properties may or may not be present

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -84,6 +84,7 @@ def is_frozendict_like(spec):
     return isinstance(spec, frozendict)
 
 def transform_dict_to_frozendict(spec):
+    print('ttttttt')
     for key, value in iteritems(spec):
         if is_list_like(value):
             spec[key] = transfer_list_to_tuple(value)
@@ -190,7 +191,7 @@ def handle_null_value(swagger_spec, schema_object_spec):
     raise SwaggerMappingError(
         'Spec {0} is a required value'.format(schema_object_spec))
 
-@clru_cache(maxsize=325, typed=False)
+#@clru_cache(maxsize=325, typed=False)
 def collapsed_properties(model_spec, swagger_spec):
     """Processes model spec and outputs dictionary with attributes
     as the keys and attribute spec as the value for the model.

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -190,7 +190,7 @@ def handle_null_value(swagger_spec, schema_object_spec):
     raise SwaggerMappingError(
         'Spec {0} is a required value'.format(schema_object_spec))
 
-@clru_cache(maxsize=325, typed=False)
+#@clru_cache(maxsize=325, typed=False)
 def collapsed_properties(model_spec, swagger_spec):
     """Processes model spec and outputs dictionary with attributes
     as the keys and attribute spec as the value for the model.

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -95,7 +95,7 @@ def get_spec_for_prop(swagger_spec, object_spec, object_value, prop_name, proper
     :return: spec for the given property or None if no spec found
     :rtype: dict or None
     """
-    deref = swagger_spec.deref
+    deref = swagger_spec.fast_deref
 
     if properties is None:
         properties = collapsed_properties(deref(object_spec), swagger_spec)

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -206,6 +206,8 @@ def collapsed_properties(model_spec, swagger_spec):
     # properties may or may not be present
     if 'properties' in model_spec:
         for attr, attr_spec in iteritems(model_spec['properties']):
+            if is_dict_like(attr_spec):
+                attr_spec = transform_dict_to_frozendict(attr_spec)
             properties[attr] = attr_spec
             print(attr_spec)
 

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -139,6 +139,7 @@ def get_spec_for_prop(swagger_spec, object_spec, object_value, prop_name, proper
     prop_spec = properties.get(prop_name)
 
     if prop_spec is not None:
+        print(prop_spec)
         result_spec = deref(prop_spec)
         # If the de-referenced specification is for a x-nullable property
         # then copy the spec and add the x-nullable property.
@@ -209,7 +210,6 @@ def collapsed_properties(model_spec, swagger_spec):
             if is_dict_like(attr_spec):
                 attr_spec = transform_dict_to_frozendict(attr_spec)
             properties[attr] = attr_spec
-            print(attr_spec)
 
     # allOf may or may not be present
     if 'allOf' in model_spec:

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -168,7 +168,7 @@ def collapsed_properties(model_spec, swagger_spec):
     try:
         return cache[id]
     except KeyError:
-        print(id)
+        print(model_spec)
         properties = {}
 
     # properties may or may not be present

--- a/bravado_core/schema.py
+++ b/bravado_core/schema.py
@@ -136,6 +136,7 @@ def get_spec_for_prop(swagger_spec, object_spec, object_value, prop_name, proper
 
     if properties is None:
         properties = collapsed_properties(deref(object_spec), swagger_spec)
+        print(properties)
     prop_spec = properties.get(prop_name)
 
     if prop_spec is not None:

--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -228,6 +228,7 @@ class Spec(object):
         try:
              return cache[i]
         except KeyError:
+            print('11')
             if ref_dict is None or not is_ref_fast(ref_dict):
                 cache[i] = ref_dict
                 return ref_dict

--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -213,7 +213,7 @@ class Spec(object):
             return cache[i]
         except KeyError:
             if ref_dict is None or not is_ref(ref_dict):
-                cache[id] = ref_dict
+                cache[i] = ref_dict
                 return ref_dict
 
         # Restore attached resolution scope before resolving since the

--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -230,7 +230,6 @@ class Spec(object):
 
     # NOTE: deref gets overridden, if internally_dereference_refs is enabled, after calling build
     deref = _force_deref
-    fast_deref = _fast_deref
 
     def get_op_for_request(self, http_method, path_pattern):
         """Return the Swagger operation for the passed in request http method

--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -229,7 +229,7 @@ class Spec(object):
         """
         i = id(ref_dict)
         try:
-            print(self.cache[i])
+            #print(self.cache[i])
             return self.cache[i]
         except KeyError:
             if ref_dict is None or not is_ref(ref_dict):

--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -34,6 +34,7 @@ from bravado_core.spec_flattening import flattened_spec
 from bravado_core.util import cached_property
 from bravado_core.util import memoize_by_id
 from bravado_core.util import strip_xscope
+from frozendict import frozendict
 from fastcache import clru_cache
 
 
@@ -230,7 +231,7 @@ class Spec(object):
         # when asked to resolve.
         with in_scope(self.resolver, ref_dict):
             _, target = self.resolver.resolve(ref_dict['$ref'])
-            return target
+            return frozendict(target)
 
     # NOTE: deref gets overridden, if internally_dereference_refs is enabled, after calling build
     deref = _force_deref

--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -223,6 +223,7 @@ class Spec(object):
 
     @lru_cache(maxsize=20)
     def _fast_deref(self, ref_dict):
+        print('ttt')
         if ref_dict is None or not is_ref_fast(ref_dict):
             return ref_dict
 

--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -221,7 +221,7 @@ class Spec(object):
             _, target = self.resolver.resolve(ref_dict['$ref'])
             return target
 
-    @lru_cache(maxsize=20)
+    """@lru_cache(maxsize=20)
     def _fast_deref(self, ref_dict):
         if ref_dict is None or not is_ref_fast(ref_dict):
             return ref_dict
@@ -235,7 +235,7 @@ class Spec(object):
                 return transfer_list_to_tuple(target)
             elif isinstance(target, dict):
                 return transform_dict_to_frozendict(target)
-            return target
+            return target"""
 
     # NOTE: deref gets overridden, if internally_dereference_refs is enabled, after calling build
     deref = _force_deref

--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -221,7 +221,7 @@ class Spec(object):
             _, target = self.resolver.resolve(ref_dict['$ref'])
             return target
 
-    """@lru_cache(maxsize=20)
+    @lru_cache(maxsize=20)
     def _fast_deref(self, ref_dict):
         if ref_dict is None or not is_ref_fast(ref_dict):
             return ref_dict
@@ -235,11 +235,11 @@ class Spec(object):
                 return transfer_list_to_tuple(target)
             elif isinstance(target, dict):
                 return transform_dict_to_frozendict(target)
-            return target"""
+            return target
 
     # NOTE: deref gets overridden, if internally_dereference_refs is enabled, after calling build
     deref = _force_deref
-    #fast_deref = _fast_deref
+    fast_deref = _fast_deref
 
     def get_op_for_request(self, http_method, path_pattern):
         """Return the Swagger operation for the passed in request http method

--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -223,6 +223,7 @@ class Spec(object):
 
     @lru_cache(maxsize=20)
     def _fast_deref(self, ref_dict):
+        print('ttt')
         if ref_dict is None or not is_ref_fast(ref_dict):
             return ref_dict
 
@@ -232,9 +233,9 @@ class Spec(object):
         with in_scope(self.resolver, ref_dict):
             _, target = self.resolver.resolve(ref_dict['$ref'])
             if isinstance(target, list):
-                return tuple(target)
+                return transfer_list_to_tuple(target)
             elif isinstance(target, dict):
-                return frozendict(target)
+                return transform_dict_to_frozendict(target)
             return target
 
     # NOTE: deref gets overridden, if internally_dereference_refs is enabled, after calling build

--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -231,10 +231,8 @@ class Spec(object):
         # when asked to resolve.
         with in_scope(self.resolver, ref_dict):
             _, target = self.resolver.resolve(ref_dict['$ref'])
-            if isinstance(target, list):
-                return tuple(target)
-            else:
-                return frozendict(target)
+            print(target)
+            return target
 
     # NOTE: deref gets overridden, if internally_dereference_refs is enabled, after calling build
     deref = _force_deref

--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -124,6 +124,7 @@ class Spec(object):
         # it will be overridden by the dereferenced specs (by build method). More context in PR#263
         self._internal_spec_dict = spec_dict
         self.cache = {}
+        self.cache_schema = {}
 
     @cached_property
     def client_spec_dict(self):

--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -123,7 +123,7 @@ class Spec(object):
         # spec dict used to build resources, in case internally_dereference_refs config is enabled
         # it will be overridden by the dereferenced specs (by build method). More context in PR#263
         self._internal_spec_dict = spec_dict
-        self.cache = {}
+        self.cache_spec = {}
         self.cache_schema = {}
 
     @cached_property
@@ -230,11 +230,10 @@ class Spec(object):
         """
         i = id(ref_dict)
         try:
-            #print(self.cache[i])
-            return self.cache[i]
+            return self.cache_spec[i]
         except KeyError:
             if ref_dict is None or not is_ref(ref_dict):
-                self.cache[i] = ref_dict
+                self.cache_spec[i] = ref_dict
                 return ref_dict
 
         # Restore attached resolution scope before resolving since the
@@ -242,7 +241,7 @@ class Spec(object):
         # when asked to resolve.
             with in_scope(self.resolver, ref_dict):
                 _, target = self.resolver.resolve(ref_dict['$ref'])
-                self.cache[i] = target
+                self.cache_spec[i] = target
                 return target
 
 

--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -39,6 +39,7 @@ from functools import lru_cache
 
 
 log = logging.getLogger(__name__)
+cache = {}
 
 
 CONFIG_DEFAULTS = {
@@ -221,21 +222,27 @@ class Spec(object):
             _, target = self.resolver.resolve(ref_dict['$ref'])
             return target
 
-    @lru_cache(maxsize=20)
+    #@lru_cache(maxsize=20)
     def _fast_deref(self, ref_dict):
-        if ref_dict is None or not is_ref_fast(ref_dict):
-            return ref_dict
+        i = id(ref_dict)
+        try:
+             return cache[i]
+        except KeyError:
+            if ref_dict is None or not is_ref_fast(ref_dict):
+                cache[i] = ref_dict
+                return ref_dict
 
         # Restore attached resolution scope before resolving since the
         # resolver doesn't have a traversal history (accumulated scope_stack)
         # when asked to resolve.
-        with in_scope(self.resolver, ref_dict):
-            _, target = self.resolver.resolve(ref_dict['$ref'])
-            if isinstance(target, list):
-                return transfer_list_to_tuple(target)
-            elif isinstance(target, dict):
-                return transform_dict_to_frozendict(target)
-            return target
+            with in_scope(self.resolver, ref_dict):
+                _, target = self.resolver.resolve(ref_dict['$ref'])
+            #if isinstance(target, list):
+            #    return transfer_list_to_tuple(target)
+            #elif isinstance(target, dict):
+            #    return transform_dict_to_frozendict(target)
+                cache[i] = target
+                return target
 
     # NOTE: deref gets overridden, if internally_dereference_refs is enabled, after calling build
     deref = _force_deref

--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -228,7 +228,6 @@ class Spec(object):
         try:
              return cache[i]
         except KeyError:
-            print('11')
             if ref_dict is None or not is_ref_fast(ref_dict):
                 cache[i] = ref_dict
                 return ref_dict

--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -190,7 +190,6 @@ class Spec(object):
         self._validate_spec()
 
         model_discovery(self)
-        print(self.definitions)
 
         if self.config['internally_dereference_refs']:
             # Avoid to evaluate is_ref every time, no references are possible at this time

--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -221,7 +221,7 @@ class Spec(object):
         # when asked to resolve.
             with in_scope(self.resolver, ref_dict):
                 _, target = self.resolver.resolve(ref_dict['$ref'])
-                slef.cache[i] = ref_dict
+                self.cache[i] = ref_dict
                 return target
 
 

--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -190,6 +190,7 @@ class Spec(object):
         self._validate_spec()
 
         model_discovery(self)
+        print(self.definitions)
 
         if self.config['internally_dereference_refs']:
             # Avoid to evaluate is_ref every time, no references are possible at this time

--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -35,7 +35,6 @@ from bravado_core.util import strip_xscope
 
 
 log = logging.getLogger(__name__)
-cache = {}
 
 
 CONFIG_DEFAULTS = {
@@ -124,6 +123,7 @@ class Spec(object):
         # spec dict used to build resources, in case internally_dereference_refs config is enabled
         # it will be overridden by the dereferenced specs (by build method). More context in PR#263
         self._internal_spec_dict = spec_dict
+        self.cache = {}
 
     @cached_property
     def client_spec_dict(self):
@@ -208,21 +208,21 @@ class Spec(object):
         :return: dereferenced value of ref_dict
         :rtype: scalar, list, dict
         """
-        #i = id(ref_dict)
-        #try:
-        #    return cache[i]
-        #except KeyError:
-        if ref_dict is None or not is_ref(ref_dict):
-        #        cache[i] = ref_dict
-            return ref_dict
+        i = id(ref_dict)
+        try:
+            return self.cache[i]
+        except KeyError:
+            if ref_dict is None or not is_ref(ref_dict):
+                self.cache[i] = ref_dict
+                return ref_dict
 
         # Restore attached resolution scope before resolving since the
         # resolver doesn't have a traversal history (accumulated scope_stack)
         # when asked to resolve.
-        with in_scope(self.resolver, ref_dict):
-            _, target = self.resolver.resolve(ref_dict['$ref'])
-            #cache[i] = ref_dict
-            return target
+            with in_scope(self.resolver, ref_dict):
+                _, target = self.resolver.resolve(ref_dict['$ref'])
+                slef.cache[i] = ref_dict
+                return target
 
 
     # NOTE: deref gets overridden, if internally_dereference_refs is enabled, after calling build

--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -231,7 +231,10 @@ class Spec(object):
         # when asked to resolve.
         with in_scope(self.resolver, ref_dict):
             _, target = self.resolver.resolve(ref_dict['$ref'])
-            return frozendict(target)
+            if isinstance(target, list):
+                return tuple(target)
+            else:
+                return frozendict(target)
 
     # NOTE: deref gets overridden, if internally_dereference_refs is enabled, after calling build
     deref = _force_deref

--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -234,6 +234,7 @@ class Spec(object):
             if isinstance(target, list):
                 return transfer_list_to_tuple(target)
             elif isinstance(target, dict):
+                print('ttt')
                 return transform_dict_to_frozendict(target)
             return target
 

--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -234,7 +234,6 @@ class Spec(object):
             if isinstance(target, list):
                 return transfer_list_to_tuple(target)
             elif isinstance(target, dict):
-                print('ttt')
                 return transform_dict_to_frozendict(target)
             return target
 

--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -240,7 +240,7 @@ class Spec(object):
         # when asked to resolve.
             with in_scope(self.resolver, ref_dict):
                 _, target = self.resolver.resolve(ref_dict['$ref'])
-                self.cache[i] = ref_dict
+                self.cache[i] = target
                 return target
 
 

--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -223,7 +223,6 @@ class Spec(object):
 
     @lru_cache(maxsize=20)
     def _fast_deref(self, ref_dict):
-        print('ttt')
         if ref_dict is None or not is_ref_fast(ref_dict):
             return ref_dict
 

--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -26,15 +26,12 @@ from bravado_core.model import model_discovery
 from bravado_core.resource import build_resources
 from bravado_core.schema import is_dict_like
 from bravado_core.schema import is_list_like
-from bravado_core.schema import transform_dict_to_frozendict
 from bravado_core.schema import is_ref
-from bravado_core.schema import is_ref_fast
 from bravado_core.security_definition import SecurityDefinition
 from bravado_core.spec_flattening import flattened_spec
 from bravado_core.util import cached_property
 from bravado_core.util import memoize_by_id
 from bravado_core.util import strip_xscope
-from frozendict import frozendict
 
 
 log = logging.getLogger(__name__)

--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -173,7 +173,6 @@ class Spec(object):
         :param http_client: http client used to download remote $refs
         :param config: Configuration dict. See CONFIG_DEFAULTS.
         """
-        spec_dict = transform_dict_to_frozendict(spec_dict)
         spec = cls(spec_dict, origin_url, http_client, config)
         spec.build()
         return spec

--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -232,17 +232,9 @@ class Spec(object):
         try:
             return self.cache_spec[i]
         except KeyError:
-            if ref_dict is None or not is_ref(ref_dict):
-                self.cache_spec[i] = ref_dict
-                return ref_dict
-
-        # Restore attached resolution scope before resolving since the
-        # resolver doesn't have a traversal history (accumulated scope_stack)
-        # when asked to resolve.
-            with in_scope(self.resolver, ref_dict):
-                _, target = self.resolver.resolve(ref_dict['$ref'])
-                self.cache_spec[i] = target
-                return target
+            result = _force_deref(self, ref_dict)
+            self.cache_spec[i] = result;
+            return result
 
 
     # NOTE: deref gets overridden, if internally_dereference_refs is enabled, after calling build

--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -208,6 +208,25 @@ class Spec(object):
         :return: dereferenced value of ref_dict
         :rtype: scalar, list, dict
         """
+
+        if ref_dict is None or not is_ref(ref_dict):
+            return ref_dict
+
+        # Restore attached resolution scope before resolving since the
+        # resolver doesn't have a traversal history (accumulated scope_stack)
+        # when asked to resolve.
+        with in_scope(self.resolver, ref_dict):
+            _, target = self.resolver.resolve(ref_dict['$ref'])
+            return target
+
+    def fast_deref(self, ref_dict):
+        """Dereference ref_dict (if it is indeed a ref) and return what the
+        ref points to.
+
+        :param ref_dict:  {'$ref': '#/blah/blah'}
+        :return: dereferenced value of ref_dict
+        :rtype: scalar, list, dict
+        """
         i = id(ref_dict)
         try:
             return self.cache[i]
@@ -227,6 +246,7 @@ class Spec(object):
 
     # NOTE: deref gets overridden, if internally_dereference_refs is enabled, after calling build
     deref = _force_deref
+    fast_deref = fast_deref
 
     def get_op_for_request(self, http_method, path_pattern):
         """Return the Swagger operation for the passed in request http method

--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -231,7 +231,6 @@ class Spec(object):
         # when asked to resolve.
         with in_scope(self.resolver, ref_dict):
             _, target = self.resolver.resolve(ref_dict['$ref'])
-            print(target)
             return target
 
     # NOTE: deref gets overridden, if internally_dereference_refs is enabled, after calling build

--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -233,6 +233,7 @@ class Spec(object):
         except KeyError:
             if ref_dict is None or not is_ref(ref_dict):
                 self.cache[i] = ref_dict
+                print('ttt')
                 return ref_dict
 
         # Restore attached resolution scope before resolving since the

--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -232,7 +232,7 @@ class Spec(object):
         try:
             return self.cache_spec[i]
         except KeyError:
-            result = _force_deref(self, ref_dict)
+            result = self._force_deref(ref_dict)
             self.cache_spec[i] = result;
             return result
 

--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -35,7 +35,7 @@ from bravado_core.util import cached_property
 from bravado_core.util import memoize_by_id
 from bravado_core.util import strip_xscope
 from frozendict import frozendict
-from fastcache import clru_cache
+from functools import lru_cache
 
 
 log = logging.getLogger(__name__)
@@ -221,7 +221,7 @@ class Spec(object):
             _, target = self.resolver.resolve(ref_dict['$ref'])
             return target
 
-    @clru_cache(maxsize=325, typed=False)
+    @lru_cache(maxsize=325)
     def _fast_deref(self, ref_dict):
         if ref_dict is None or not is_ref_fast(ref_dict):
             return ref_dict

--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -231,6 +231,10 @@ class Spec(object):
         # when asked to resolve.
         with in_scope(self.resolver, ref_dict):
             _, target = self.resolver.resolve(ref_dict['$ref'])
+            if isinstance(target, list):
+                return transfer_list_to_tuple(target)
+            elif isinstance(target, dict):
+                return transform_dict_to_frozendict(target)
             return target
 
     # NOTE: deref gets overridden, if internally_dereference_refs is enabled, after calling build

--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -229,6 +229,7 @@ class Spec(object):
         """
         i = id(ref_dict)
         try:
+            print(self.cache[i])
             return self.cache[i]
         except KeyError:
             if ref_dict is None or not is_ref(ref_dict):

--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -229,7 +229,6 @@ class Spec(object):
         """
         i = id(ref_dict)
         try:
-            print(ref_dict)
             return self.cache[i]
         except KeyError:
             if ref_dict is None or not is_ref(ref_dict):

--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -239,7 +239,7 @@ class Spec(object):
 
     # NOTE: deref gets overridden, if internally_dereference_refs is enabled, after calling build
     deref = _force_deref
-    fast_deref = _fast_deref
+    #fast_deref = _fast_deref
 
     def get_op_for_request(self, http_method, path_pattern):
         """Return the Swagger operation for the passed in request http method

--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -229,11 +229,11 @@ class Spec(object):
         """
         i = id(ref_dict)
         try:
+            print(ref_dict)
             return self.cache[i]
         except KeyError:
             if ref_dict is None or not is_ref(ref_dict):
                 self.cache[i] = ref_dict
-                print('ttt')
                 return ref_dict
 
         # Restore attached resolution scope before resolving since the

--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -208,21 +208,21 @@ class Spec(object):
         :return: dereferenced value of ref_dict
         :rtype: scalar, list, dict
         """
-        i = id(ref_dict)
-        try:
-            return cache[i]
-        except KeyError:
-            if ref_dict is None or not is_ref(ref_dict):
-                cache[i] = ref_dict
-                return ref_dict
+        #i = id(ref_dict)
+        #try:
+        #    return cache[i]
+        #except KeyError:
+        if ref_dict is None or not is_ref(ref_dict):
+        #        cache[i] = ref_dict
+            return ref_dict
 
         # Restore attached resolution scope before resolving since the
         # resolver doesn't have a traversal history (accumulated scope_stack)
         # when asked to resolve.
-            with in_scope(self.resolver, ref_dict):
-                _, target = self.resolver.resolve(ref_dict['$ref'])
-                cache[i] = ref_dict
-                return target
+        with in_scope(self.resolver, ref_dict):
+            _, target = self.resolver.resolve(ref_dict['$ref'])
+            #cache[i] = ref_dict
+            return target
 
 
     # NOTE: deref gets overridden, if internally_dereference_refs is enabled, after calling build

--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -232,9 +232,9 @@ class Spec(object):
         with in_scope(self.resolver, ref_dict):
             _, target = self.resolver.resolve(ref_dict['$ref'])
             if isinstance(target, list):
-                return transfer_list_to_tuple(target)
+                return tuple(target)
             elif isinstance(target, dict):
-                return transform_dict_to_frozendict(target)
+                return frozendict(target)
             return target
 
     # NOTE: deref gets overridden, if internally_dereference_refs is enabled, after calling build

--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -221,7 +221,7 @@ class Spec(object):
             _, target = self.resolver.resolve(ref_dict['$ref'])
             return target
 
-    @lru_cache(maxsize=325)
+    @lru_cache(maxsize=20)
     def _fast_deref(self, ref_dict):
         if ref_dict is None or not is_ref_fast(ref_dict):
             return ref_dict

--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -208,9 +208,9 @@ class Spec(object):
         :return: dereferenced value of ref_dict
         :rtype: scalar, list, dict
         """
-        id = id(ref_dict)
+        i = id(ref_dict)
         try:
-            return cache[id]
+            return cache[i]
         except KeyError:
             if ref_dict is None or not is_ref(ref_dict):
                 cache[id] = ref_dict
@@ -221,7 +221,7 @@ class Spec(object):
         # when asked to resolve.
             with in_scope(self.resolver, ref_dict):
                 _, target = self.resolver.resolve(ref_dict['$ref'])
-                cache[id] = ref_dict
+                cache[i] = ref_dict
                 return target
 
 

--- a/bravado_core/spec.py
+++ b/bravado_core/spec.py
@@ -26,6 +26,7 @@ from bravado_core.model import model_discovery
 from bravado_core.resource import build_resources
 from bravado_core.schema import is_dict_like
 from bravado_core.schema import is_list_like
+from bravado_core.schema import transform_dict_to_frozendict
 from bravado_core.schema import is_ref
 from bravado_core.schema import is_ref_fast
 from bravado_core.security_definition import SecurityDefinition
@@ -172,6 +173,7 @@ class Spec(object):
         :param http_client: http client used to download remote $refs
         :param config: Configuration dict. See CONFIG_DEFAULTS.
         """
+        spec_dict = transform_dict_to_frozendict(spec_dict)
         spec = cls(spec_dict, origin_url, http_client, config)
         spec.build()
         return spec

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -6,30 +6,27 @@ from bravado_core import schema
 from bravado_core.exception import SwaggerMappingError
 from bravado_core.model import is_model
 from bravado_core.model import MODEL_MARKER
-from bravado_core.schema import collapsed_properties
+from bravado_core.schema import fast_collapsed_properties
 from bravado_core.schema import get_spec_for_prop
 from bravado_core.schema import handle_null_value
 from bravado_core.schema import is_dict_like
 from bravado_core.schema import is_list_like
 from bravado_core.schema import SWAGGER_PRIMITIVES
 
+
 def unmarshal_schema_object(swagger_spec, schema_object_spec, value):
     """Unmarshal the value using the given schema object specification.
-
     Unmarshalling includes:
     - transform the value according to 'format' if available
     - return the value in a form suitable for use. e.g. conversion to a Model
       type.
-
     :type swagger_spec: :class:`bravado_core.spec.Spec`
     :type schema_object_spec: dict
     :type value: int, float, long, string, unicode, boolean, list, dict, etc
-
     :return: unmarshalled value
     :rtype: int, float, long, string, unicode, boolean, list, dict, object (in
         the case of a 'format' conversion', or Model type
     """
-
     deref = swagger_spec.fast_deref
     schema_object_spec = deref(schema_object_spec)
 
@@ -70,11 +67,9 @@ def unmarshal_schema_object(swagger_spec, schema_object_spec, value):
 
 def unmarshal_primitive(swagger_spec, primitive_spec, value):
     """Unmarshal a jsonschema primitive type into a python primitive.
-
     :type swagger_spec: :class:`bravado_core.spec.Spec`
     :type primitive_spec: dict
     :type value: int, long, float, boolean, string, unicode, etc
-
     :rtype: int, long, float, boolean, string, unicode, or an object
         based on 'format'
     :raises: SwaggerMappingError
@@ -88,7 +83,6 @@ def unmarshal_primitive(swagger_spec, primitive_spec, value):
 
 def unmarshal_array(swagger_spec, array_spec, array_value):
     """Unmarshal a jsonschema type of 'array' into a python list.
-
     :type swagger_spec: :class:`bravado_core.spec.Spec`
     :type array_spec: dict
     :type array_value: list
@@ -111,7 +105,6 @@ def unmarshal_array(swagger_spec, array_spec, array_value):
 
 def unmarshal_object(swagger_spec, object_spec, object_value):
     """Unmarshal a jsonschema type of 'object' into a python dict.
-
     :type swagger_spec: :class:`bravado_core.spec.Spec`
     :type object_spec: dict
     :type object_value: dict
@@ -129,8 +122,7 @@ def unmarshal_object(swagger_spec, object_spec, object_value):
 
     object_spec = deref(object_spec)
     required_fields = object_spec.get('required', [])
-    properties = collapsed_properties(object_spec, swagger_spec)
-    #print(collapsed_properties.cache_info())
+    properties = fast_collapsed_properties(object_spec, swagger_spec)
 
     result = {}
     for k, v in iteritems(object_value):
@@ -158,17 +150,14 @@ def unmarshal_object(swagger_spec, object_spec, object_value):
 
 def unmarshal_model(swagger_spec, model_spec, model_value):
     """Unmarshal a dict into a Model instance.
-
     :type swagger_spec: :class:`bravado_core.spec.Spec`
     :type model_spec: dict
     :type model_value: dict
     :rtype: Model instance
     :raises: SwaggerMappingError
     """
-
     deref = swagger_spec.fast_deref
     model_name = deref(model_spec).get(MODEL_MARKER)
-
     model_type = swagger_spec.definitions.get(model_name, None)
 
     if model_type is None:

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -39,7 +39,7 @@ def unmarshal_schema_object(swagger_spec, schema_object_spec, value):
 
     deref = swagger_spec.fast_deref
     schema_object_spec = deref(schema_object_spec)
-    deref.cache_info()
+    print(deref.cache_info())
 
     obj_type = schema_object_spec.get('type')
 

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -37,13 +37,13 @@ def unmarshal_schema_object(swagger_spec, schema_object_spec, value):
     #    print(type(schema_object_spec))
     #    schema_object_spec = transform_dict_to_frozendict(schema_object_spec)
 
-    if is_frozendict_like(schema_object_spec):
-        deref = swagger_spec.fast_deref
-        schema_object_spec = deref(schema_object_spec)
+    #if is_frozendict_like(schema_object_spec):
+    #    deref = swagger_spec.fast_deref
+    #    schema_object_spec = deref(schema_object_spec)
         #print(deref.cache_info())
-    else:
-        deref = swagger_spec.deref
-        schema_object_spec = frozendict(deref(schema_object_spec))
+    #else:
+    deref = swagger_spec.deref
+    schema_object_spec = frozendict(deref(schema_object_spec))
     #schema_object_spec = deref(schema_object_spec)
     #print(schema_object_spec)
     #

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -38,6 +38,7 @@ def unmarshal_schema_object(swagger_spec, schema_object_spec, value):
     #    schema_object_spec = transform_dict_to_frozendict(schema_object_spec)
 
     if is_frozendict_like(schema_object_spec):
+        print(schema_object_spec)
         deref = swagger_spec.fast_deref
     else:
         deref = swagger_spec.deref

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -142,7 +142,6 @@ def unmarshal_object(swagger_spec, object_spec, object_value):
     for k, v in iteritems(object_value):
         prop_spec = get_spec_for_prop(
             swagger_spec, object_spec, object_value, k, properties)
-        print(type(prop_spec))
         if v is None and k not in required_fields and prop_spec:
             if schema.has_default(swagger_spec, prop_spec):
                 result[k] = schema.get_default(swagger_spec, prop_spec)
@@ -152,6 +151,7 @@ def unmarshal_object(swagger_spec, object_spec, object_value):
             result[k] = unmarshal_schema_object(swagger_spec, prop_spec, v)
         else:
             # Don't marshal when a spec is not available - just pass through
+            print(v)
             result[k] = v
 
     for prop_name, prop_spec in iteritems(properties):

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -180,7 +180,7 @@ def unmarshal_model(swagger_spec, model_spec, model_value):
     #if not is_frozendict_like(model_spec) and is_dict_like(model_spec):
     #    model_spec = transform_dict_to_frozendict(model_spec)
     if not is_frozendict_like(model_spec):
-        model_spec = frozendict(model_spec)
+        model_spec = transform_dict_to_frozendict(model_spec)
     deref = swagger_spec.fast_deref
     #print(deref.cache_info())
     model_name = deref(model_spec).get(MODEL_MARKER)

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -36,6 +36,7 @@ def unmarshal_schema_object(swagger_spec, schema_object_spec, value):
     #if not is_frozendict_like(schema_object_spec) and not is_list_like(schema_object_spec):
     #    print(type(schema_object_spec))
     #    schema_object_spec = transform_dict_to_frozendict(schema_object_spec)
+    print(schema_object_spec)
 
     if is_frozendict_like(schema_object_spec):
         deref = swagger_spec.fast_deref

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -41,7 +41,7 @@ def unmarshal_schema_object(swagger_spec, schema_object_spec, value):
         deref = swagger_spec.fast_deref
     else:
         deref = swagger_spec.deref
-    #print(schema_object_spec)
+    print(schema_object_spec)
     schema_object_spec = deref(schema_object_spec)
     #print(deref.cache_info())
 

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -34,7 +34,7 @@ def unmarshal_schema_object(swagger_spec, schema_object_spec, value):
         the case of a 'format' conversion', or Model type
     """
     if not is_frozendict_like(schema_object_spec) and not is_list_like(schema_object_spec):
-        print(type(schema_object_spec))
+        #print(type(schema_object_spec))
         schema_object_spec = transform_dict_to_frozendict(schema_object_spec)
 
     deref = swagger_spec.fast_deref
@@ -148,6 +148,7 @@ def unmarshal_object(swagger_spec, object_spec, object_value):
             else:
                 result[k] = None
         elif prop_spec:
+            print(type(prop_spec))
             result[k] = unmarshal_schema_object(swagger_spec, prop_spec, v)
         else:
             # Don't marshal when a spec is not available - just pass through

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -45,7 +45,7 @@ def unmarshal_schema_object(swagger_spec, schema_object_spec, value):
         deref = swagger_spec.deref
         schema_object_spec = frozendict(deref(schema_object_spec))
     #schema_object_spec = deref(schema_object_spec)
-    print(schema_object_spec)
+    #print(schema_object_spec)
     #
 
     obj_type = schema_object_spec.get('type')
@@ -157,6 +157,7 @@ def unmarshal_object(swagger_spec, object_spec, object_value):
             else:
                 result[k] = None
         elif prop_spec:
+            print(prop_spec)
             result[k] = unmarshal_schema_object(swagger_spec, prop_spec, v)
         else:
             # Don't marshal when a spec is not available - just pass through

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -40,7 +40,7 @@ def unmarshal_schema_object(swagger_spec, schema_object_spec, value):
     if is_frozendict_like(schema_object_spec):
         deref = swagger_spec.fast_deref
         schema_object_spec = deref(schema_object_spec)
-        print(deref.cache_info())
+        #print(deref.cache_info())
     else:
         deref = swagger_spec.deref
         schema_object_spec = frozendict(deref(schema_object_spec))
@@ -145,7 +145,7 @@ def unmarshal_object(swagger_spec, object_spec, object_value):
     object_spec = deref(object_spec)
     required_fields = object_spec.get('required', [])
     properties = collapsed_properties(object_spec, swagger_spec)
-    #print(collapsed_properties.cache_info())
+    print(collapsed_properties.cache_info())
 
     result = {}
     for k, v in iteritems(object_value):

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -45,7 +45,7 @@ def unmarshal_schema_object(swagger_spec, schema_object_spec, value):
         deref = swagger_spec.deref
         schema_object_spec = frozendict(deref(schema_object_spec))
     #schema_object_spec = deref(schema_object_spec)
-    #print(schema_object_spec)
+    print(schema_object_spec)
     #
 
     obj_type = schema_object_spec.get('type')
@@ -118,7 +118,6 @@ def unmarshal_array(swagger_spec, array_spec, array_value):
             type(array_value), array_value))
 
     item_spec = swagger_spec.fast_deref(array_spec).get('items')
-    print(item_spec)
     return [
         unmarshal_schema_object(swagger_spec, item_spec, item)
         for item in array_value

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -63,9 +63,11 @@ def unmarshal_schema_object(swagger_spec, schema_object_spec, value):
         # It is important that the 'model' check comes before 'object' check.
         # Model specs also have type 'object' but also have the additional
         # MODEL_MARKER key for identification.
+        print('hi')
         return unmarshal_model(swagger_spec, schema_object_spec, value)
 
     if obj_type == 'object':
+        print('hi2')
         return unmarshal_object(swagger_spec, schema_object_spec, value)
 
     if obj_type == 'file':
@@ -202,7 +204,7 @@ def unmarshal_model(swagger_spec, model_spec, model_value):
             )
         model_type = swagger_spec.definitions.get(child_model_name)
         model_spec = model_type._model_spec
-    print('hi')
+
     model_as_dict = unmarshal_object(swagger_spec, model_spec, model_value)
     model_instance = model_type._from_dict(model_as_dict)
     return model_instance

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -34,7 +34,7 @@ def unmarshal_schema_object(swagger_spec, schema_object_spec, value):
         the case of a 'format' conversion', or Model type
     """
     if not is_frozendict_like(schema_object_spec) and not is_list_like(schema_object_spec):
-        #print(type(schema_object_spec))
+        print(type(schema_object_spec))
         schema_object_spec = transform_dict_to_frozendict(schema_object_spec)
 
     deref = swagger_spec.fast_deref

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -41,6 +41,7 @@ def unmarshal_schema_object(swagger_spec, schema_object_spec, value):
         deref = swagger_spec.fast_deref
     else:
         deref = swagger_spec.deref
+    print(schema_object_spec)
     schema_object_spec = deref(schema_object_spec)
     #print(deref.cache_info())
 

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -173,6 +173,8 @@ def unmarshal_model(swagger_spec, model_spec, model_value):
     :rtype: Model instance
     :raises: SwaggerMappingError
     """
+    if is_dict_like(model_spec):
+        model_spec = transform_dict_to_frozendict(model_spec)
     deref = swagger_spec.fast_deref
     model_name = deref(model_spec).get(MODEL_MARKER)
     model_type = swagger_spec.definitions.get(model_name, None)

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -150,6 +150,7 @@ def unmarshal_object(swagger_spec, object_spec, object_value):
             else:
                 result[k] = None
         elif prop_spec:
+            print(prop_spec)
             result[k] = unmarshal_schema_object(swagger_spec, prop_spec, v)
         else:
             # Don't marshal when a spec is not available - just pass through
@@ -174,7 +175,6 @@ def unmarshal_model(swagger_spec, model_spec, model_value):
     :raises: SwaggerMappingError
     """
     deref = swagger_spec.fast_deref
-    print(model_spec)
     model_name = deref(model_spec).get(MODEL_MARKER)
     model_type = swagger_spec.definitions.get(model_name, None)
 

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -36,13 +36,13 @@ def unmarshal_schema_object(swagger_spec, schema_object_spec, value):
     #if not is_frozendict_like(schema_object_spec) and not is_list_like(schema_object_spec):
     #    print(type(schema_object_spec))
     #    schema_object_spec = transform_dict_to_frozendict(schema_object_spec)
-    print(schema_object_spec)
+
     if is_frozendict_like(schema_object_spec):
         deref = swagger_spec.fast_deref
     else:
         deref = swagger_spec.deref
     schema_object_spec = deref(schema_object_spec)
-
+    print(schema_object_spec)
     #print(deref.cache_info())
 
     obj_type = schema_object_spec.get('type')

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -36,7 +36,6 @@ def unmarshal_schema_object(swagger_spec, schema_object_spec, value):
     #if not is_frozendict_like(schema_object_spec) and not is_list_like(schema_object_spec):
     #    print(type(schema_object_spec))
     #    schema_object_spec = transform_dict_to_frozendict(schema_object_spec)
-    print(schema_object_spec)
 
     if is_frozendict_like(schema_object_spec):
         deref = swagger_spec.fast_deref
@@ -46,7 +45,7 @@ def unmarshal_schema_object(swagger_spec, schema_object_spec, value):
         deref = swagger_spec.deref
         schema_object_spec = frozendict(deref(schema_object_spec))
     #schema_object_spec = deref(schema_object_spec)
-    #print(schema_object_spec)
+    print(schema_object_spec)
     #
 
     obj_type = schema_object_spec.get('type')

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -42,7 +42,7 @@ def unmarshal_schema_object(swagger_spec, schema_object_spec, value):
     else:
         deref = swagger_spec.deref
     schema_object_spec = deref(schema_object_spec)
-    #print(schema_object_spec)
+    print(schema_object_spec)
     #print(deref.cache_info())
 
     obj_type = schema_object_spec.get('type')

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -34,7 +34,7 @@ def unmarshal_schema_object(swagger_spec, schema_object_spec, value):
     #    schema_object_spec = transform_dict_to_frozendict(schema_object_spec)
 
 
-    deref = swagger_spec.deref
+    deref = swagger_spec.fast_deref
     schema_object_spec = deref(schema_object_spec)
     #schema_object_spec = deref(schema_object_spec)
     #print(schema_object_spec)
@@ -109,7 +109,7 @@ def unmarshal_array(swagger_spec, array_spec, array_value):
         raise SwaggerMappingError('Expected list like type for {0}:{1}'.format(
             type(array_value), array_value))
 
-    item_spec = swagger_spec.deref(array_spec).get('items')
+    item_spec = swagger_spec.fast_deref(array_spec).get('items')
     return [
         unmarshal_schema_object(swagger_spec, item_spec, item)
         for item in array_value
@@ -125,7 +125,7 @@ def unmarshal_object(swagger_spec, object_spec, object_value):
     :rtype: dict
     :raises: SwaggerMappingError
     """
-    deref = swagger_spec.deref
+    deref = swagger_spec.fast_deref
 
     if object_value is None:
         return handle_null_value(swagger_spec, object_spec)
@@ -174,7 +174,7 @@ def unmarshal_model(swagger_spec, model_spec, model_value):
     """
     #if not is_frozendict_like(model_spec) and is_dict_like(model_spec):
     #    model_spec = transform_dict_to_frozendict(model_spec)
-    deref = swagger_spec.deref
+    deref = swagger_spec.fast_deref
     #print(deref.cache_info())
     model_name = deref(model_spec).get(MODEL_MARKER)
 

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -40,7 +40,7 @@ def unmarshal_schema_object(swagger_spec, schema_object_spec, value):
     if is_frozendict_like(schema_object_spec):
         deref = swagger_spec.fast_deref
         schema_object_spec = deref(schema_object_spec)
-        print(deref.cache_info())
+        #print(deref.cache_info())
     else:
         deref = swagger_spec.deref
         schema_object_spec = frozendict(deref(schema_object_spec))

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -138,6 +138,7 @@ def unmarshal_object(swagger_spec, object_spec, object_value):
     object_spec = deref(object_spec)
     required_fields = object_spec.get('required', [])
     properties = collapsed_properties(object_spec, swagger_spec)
+    print(properties)
 
     result = {}
     for k, v in iteritems(object_value):
@@ -149,7 +150,6 @@ def unmarshal_object(swagger_spec, object_spec, object_value):
             else:
                 result[k] = None
         elif prop_spec:
-            print(prop_spec)
             result[k] = unmarshal_schema_object(swagger_spec, prop_spec, v)
         else:
             # Don't marshal when a spec is not available - just pass through

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -214,7 +214,7 @@ def unmarshal_model(swagger_spec, model_spec, model_value):
             )
         model_type = swagger_spec.definitions.get(child_model_name)
         model_spec = model_type._model_spec
-
+    print(model_spec)
     model_as_dict = unmarshal_object(swagger_spec, model_spec, model_value)
     model_instance = model_type._from_dict(model_as_dict)
     return model_instance

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -174,6 +174,7 @@ def unmarshal_model(swagger_spec, model_spec, model_value):
     :raises: SwaggerMappingError
     """
     deref = swagger_spec.fast_deref
+    print(model_spec)
     model_name = deref(model_spec).get(MODEL_MARKER)
     model_type = swagger_spec.definitions.get(model_name, None)
 

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -150,7 +150,7 @@ def unmarshal_object(swagger_spec, object_spec, object_value):
     result = {}
     for k, v in iteritems(object_value):
         prop_spec = get_spec_for_prop(
-            swagger_spec, object_spec, k, properties)
+            swagger_spec, object_spec, object_value, k, properties)
         if v is None and k not in required_fields and prop_spec:
             if schema.has_default(swagger_spec, prop_spec):
                 result[k] = schema.get_default(swagger_spec, prop_spec)

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -16,6 +16,10 @@ from bravado_core.schema import is_list_like
 from bravado_core.schema import SWAGGER_PRIMITIVES
 from frozendict import frozendict
 
+def unmarshal(swagger_spec, schema_object_spec, value):
+    deref = swagger_spec.deref
+    schema_object_spec = frozendict(deref(schema_object_spec))
+    return unmarshal_schema_object(swagger_spec, schema_object_spec, value)
 
 def unmarshal_schema_object(swagger_spec, schema_object_spec, value):
     """Unmarshal the value using the given schema object specification.
@@ -37,13 +41,13 @@ def unmarshal_schema_object(swagger_spec, schema_object_spec, value):
     #    print(type(schema_object_spec))
     #    schema_object_spec = transform_dict_to_frozendict(schema_object_spec)
 
-    if is_frozendict_like(schema_object_spec):
-        deref = swagger_spec.fast_deref
-        schema_object_spec = deref(schema_object_spec)
+    #if is_frozendict_like(schema_object_spec):
+    deref = swagger_spec.fast_deref
+    schema_object_spec = deref(schema_object_spec)
         #print(deref.cache_info())
-    else:
-        deref = swagger_spec.deref
-        schema_object_spec = frozendict(deref(schema_object_spec))
+    #else:
+    #    deref = swagger_spec.deref
+    #    schema_object_spec = frozendict(deref(schema_object_spec))
     #schema_object_spec = deref(schema_object_spec)
     #print(schema_object_spec)
     #

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -177,7 +177,6 @@ def unmarshal_model(swagger_spec, model_spec, model_value):
     :raises: SwaggerMappingError
     """
     if not is_frozendict_like(model_spec) and is_dict_like(model_spec):
-        print('ttt')
         model_spec = transform_dict_to_frozendict(model_spec)
     deref = swagger_spec.fast_deref
     #print(deref.cache_info())

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -33,11 +33,11 @@ def unmarshal_schema_object(swagger_spec, schema_object_spec, value):
     #    print(type(schema_object_spec))
     #    schema_object_spec = transform_dict_to_frozendict(schema_object_spec)
 
-    print(schema_object_spec)
+    #print(schema_object_spec)
     deref = swagger_spec.fast_deref
     schema_object_spec = deref(schema_object_spec)
     #schema_object_spec = deref(schema_object_spec)
-    print(schema_object_spec)
+    #print(schema_object_spec)
     #
 
     obj_type = schema_object_spec.get('type')

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -117,6 +117,7 @@ def unmarshal_array(swagger_spec, array_spec, array_value):
         raise SwaggerMappingError('Expected list like type for {0}:{1}'.format(
             type(array_value), array_value))
 
+    print(array_spec)
     item_spec = swagger_spec.fast_deref(array_spec).get('items')
     return [
         unmarshal_schema_object(swagger_spec, item_spec, item)
@@ -215,7 +216,6 @@ def unmarshal_model(swagger_spec, model_spec, model_value):
             )
         model_type = swagger_spec.definitions.get(child_model_name)
         model_spec = model_type._model_spec
-        print(type(model_spec))
 
     model_as_dict = unmarshal_object(swagger_spec, model_spec, model_value)
     model_instance = model_type._from_dict(model_as_dict)

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -139,7 +139,7 @@ def unmarshal_object(swagger_spec, object_spec, object_value):
     object_spec = deref(object_spec)
     required_fields = object_spec.get('required', [])
     properties = collapsed_properties(object_spec, swagger_spec)
-    #print(collapsed_properties.cache_info())
+    print(collapsed_properties.cache_info())
 
     result = {}
     for k, v in iteritems(object_value):

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -111,7 +111,7 @@ def unmarshal_array(swagger_spec, array_spec, array_value):
         raise SwaggerMappingError('Expected list like type for {0}:{1}'.format(
             type(array_value), array_value))
 
-    item_spec = swagger_spec.deref(array_spec).get('items')
+    item_spec = transform_dict_to_frozendict(swagger_spec.deref(array_spec).get('items'))
     return [
         unmarshal_schema_object(swagger_spec, item_spec, item)
         for item in array_value

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -37,13 +37,13 @@ def unmarshal_schema_object(swagger_spec, schema_object_spec, value):
     #    print(type(schema_object_spec))
     #    schema_object_spec = transform_dict_to_frozendict(schema_object_spec)
 
-    if is_frozendict_like(schema_object_spec):
-        deref = swagger_spec.fast_deref
-        schema_object_spec = deref(schema_object_spec)
+    #if is_frozendict_like(schema_object_spec):
+    #    deref = swagger_spec.fast_deref
+    #    schema_object_spec = deref(schema_object_spec)
         #print(deref.cache_info())
-    else:
-        deref = swagger_spec.deref
-        schema_object_spec = frozendict(deref(schema_object_spec))
+    #else:
+    deref = swagger_spec.deref
+    schema_object_spec = frozendict(deref(schema_object_spec))
     #schema_object_spec = deref(schema_object_spec)
     #print(schema_object_spec)
     #
@@ -117,7 +117,7 @@ def unmarshal_array(swagger_spec, array_spec, array_value):
         raise SwaggerMappingError('Expected list like type for {0}:{1}'.format(
             type(array_value), array_value))
 
-    item_spec = swagger_spec.fast_deref(array_spec).get('items')
+    item_spec = frozendict(swagger_spec.deref(array_spec)).get('items')
     return [
         unmarshal_schema_object(swagger_spec, item_spec, item)
         for item in array_value
@@ -133,7 +133,7 @@ def unmarshal_object(swagger_spec, object_spec, object_value):
     :rtype: dict
     :raises: SwaggerMappingError
     """
-    deref = swagger_spec.fast_deref
+    deref = swagger_spec.deref
 
     if object_value is None:
         return handle_null_value(swagger_spec, object_spec)
@@ -142,7 +142,7 @@ def unmarshal_object(swagger_spec, object_spec, object_value):
         raise SwaggerMappingError('Expected dict like type for {0}:{1}'.format(
             type(object_value), object_value))
 
-    object_spec = deref(object_spec)
+    object_spec = frozendict(deref(object_spec))
     required_fields = object_spec.get('required', [])
     properties = collapsed_properties(object_spec, swagger_spec)
     #print(collapsed_properties.cache_info())
@@ -182,7 +182,7 @@ def unmarshal_model(swagger_spec, model_spec, model_value):
     """
     #if not is_frozendict_like(model_spec) and is_dict_like(model_spec):
     #    model_spec = transform_dict_to_frozendict(model_spec)
-    deref = swagger_spec.fast_deref
+    deref = swagger_spec.deref
     #print(deref.cache_info())
     model_name = deref(model_spec).get(MODEL_MARKER)
 

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -40,7 +40,7 @@ def unmarshal_schema_object(swagger_spec, schema_object_spec, value):
     if is_frozendict_like(schema_object_spec):
         deref = swagger_spec.fast_deref
         schema_object_spec = deref(schema_object_spec)
-        #print(deref.cache_info())
+        print(deref.cache_info())
     else:
         deref = swagger_spec.deref
         schema_object_spec = frozendict(deref(schema_object_spec))

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -182,7 +182,6 @@ def unmarshal_model(swagger_spec, model_spec, model_value):
     """
     #if not is_frozendict_like(model_spec) and is_dict_like(model_spec):
     #    model_spec = transform_dict_to_frozendict(model_spec)
-    print(model_spec)
     deref = swagger_spec.fast_deref
     #print(deref.cache_info())
     model_name = deref(model_spec).get(MODEL_MARKER)

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -136,6 +136,7 @@ def unmarshal_object(swagger_spec, object_spec, object_value):
     object_spec = deref(object_spec)
     required_fields = object_spec.get('required', [])
     properties = collapsed_properties(object_spec, swagger_spec)
+    print(properties)
 
     result = {}
     for k, v in iteritems(object_value):

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -37,13 +37,13 @@ def unmarshal_schema_object(swagger_spec, schema_object_spec, value):
     #    print(type(schema_object_spec))
     #    schema_object_spec = transform_dict_to_frozendict(schema_object_spec)
 
-    #if is_frozendict_like(schema_object_spec):
-    deref = swagger_spec.fast_deref
-    schema_object_spec = deref(schema_object_spec)
+    if is_frozendict_like(schema_object_spec):
+        deref = swagger_spec.fast_deref
+        schema_object_spec = deref(schema_object_spec)
         #print(deref.cache_info())
-    #else:
-    #    deref = swagger_spec.deref
-    #    schema_object_spec = frozendict(deref(schema_object_spec))
+    else:
+        deref = swagger_spec.deref
+        schema_object_spec = frozendict(deref(schema_object_spec))
     #schema_object_spec = deref(schema_object_spec)
     #print(schema_object_spec)
     #

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -126,7 +126,7 @@ def unmarshal_object(swagger_spec, object_spec, object_value):
     :rtype: dict
     :raises: SwaggerMappingError
     """
-    deref = swagger_spec.deref
+    deref = swagger_spec.fast_deref
 
     if object_value is None:
         return handle_null_value(swagger_spec, object_spec)

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -177,6 +177,7 @@ def unmarshal_model(swagger_spec, model_spec, model_value):
     :raises: SwaggerMappingError
     """
     if not is_frozendict_like(model_spec) and is_dict_like(model_spec):
+        print('ttt')
         model_spec = transform_dict_to_frozendict(model_spec)
     deref = swagger_spec.fast_deref
     #print(deref.cache_info())

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -202,7 +202,7 @@ def unmarshal_model(swagger_spec, model_spec, model_value):
             )
         model_type = swagger_spec.definitions.get(child_model_name)
         model_spec = model_type._model_spec
-
+    print('hi')
     model_as_dict = unmarshal_object(swagger_spec, model_spec, model_value)
     model_instance = model_type._from_dict(model_as_dict)
     return model_instance

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -43,6 +43,7 @@ def unmarshal_schema_object(swagger_spec, schema_object_spec, value):
         #print(deref.cache_info())
     else:
         deref = swagger_spec.deref
+        print(schema_object_spec)
         schema_object_spec = frozendict(deref(schema_object_spec))
     #schema_object_spec = deref(schema_object_spec)
     #print(schema_object_spec)
@@ -145,7 +146,7 @@ def unmarshal_object(swagger_spec, object_spec, object_value):
     object_spec = deref(object_spec)
     required_fields = object_spec.get('required', [])
     properties = collapsed_properties(object_spec, swagger_spec)
-    print(collapsed_properties.cache_info())
+    #print(collapsed_properties.cache_info())
 
     result = {}
     for k, v in iteritems(object_value):

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -141,7 +141,7 @@ def unmarshal_object(swagger_spec, object_spec, object_value):
     object_spec = deref(object_spec)
     required_fields = object_spec.get('required', [])
     properties = collapsed_properties(object_spec, swagger_spec)
-    #print(collapsed_properties.cache_info())
+    print(collapsed_properties.cache_info())
 
     result = {}
     for k, v in iteritems(object_value):

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -37,13 +37,13 @@ def unmarshal_schema_object(swagger_spec, schema_object_spec, value):
     #    print(type(schema_object_spec))
     #    schema_object_spec = transform_dict_to_frozendict(schema_object_spec)
 
-    #if is_frozendict_like(schema_object_spec):
-    #    deref = swagger_spec.fast_deref
-    #    schema_object_spec = deref(schema_object_spec)
+    if is_frozendict_like(schema_object_spec):
+        deref = swagger_spec.fast_deref
+        schema_object_spec = deref(schema_object_spec)
         #print(deref.cache_info())
-    #else:
-    deref = swagger_spec.deref
-    schema_object_spec = frozendict(deref(schema_object_spec))
+    else:
+        deref = swagger_spec.deref
+        schema_object_spec = frozendict(deref(schema_object_spec))
     #schema_object_spec = deref(schema_object_spec)
     #print(schema_object_spec)
     #

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -176,7 +176,7 @@ def unmarshal_model(swagger_spec, model_spec, model_value):
     if is_dict_like(model_spec):
         model_spec = transform_dict_to_frozendict(model_spec)
     deref = swagger_spec.fast_deref
-    print(deref.cache_info())
+    #print(deref.cache_info())
     model_name = deref(model_spec).get(MODEL_MARKER)
 
     model_type = swagger_spec.definitions.get(model_name, None)

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -101,7 +101,6 @@ def unmarshal_array(swagger_spec, array_spec, array_value):
     :rtype: list
     :raises: SwaggerMappingError
     """
-    print(array_spec)
     if array_value is None:
         return handle_null_value(swagger_spec, array_spec)
 

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -40,6 +40,7 @@ def unmarshal_schema_object(swagger_spec, schema_object_spec, value):
     deref = swagger_spec.deref
     schema_object_spec = deref(schema_object_spec)
     #print(deref.cache_info())
+    print('start')
 
     obj_type = schema_object_spec.get('type')
 

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -36,7 +36,6 @@ def unmarshal_schema_object(swagger_spec, schema_object_spec, value):
     if not is_frozendict_like(schema_object_spec) and not is_list_like(schema_object_spec):
         #print(type(schema_object_spec))
         schema_object_spec = transform_dict_to_frozendict(schema_object_spec)
-        print(schema_object_spec)
 
     deref = swagger_spec.fast_deref
     schema_object_spec = deref(schema_object_spec)

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -134,7 +134,6 @@ def unmarshal_object(swagger_spec, object_spec, object_value):
     :raises: SwaggerMappingError
     """
     deref = swagger_spec.fast_deref
-    print(object_spec)
 
     if object_value is None:
         return handle_null_value(swagger_spec, object_spec)
@@ -146,7 +145,7 @@ def unmarshal_object(swagger_spec, object_spec, object_value):
     object_spec = deref(object_spec)
     required_fields = object_spec.get('required', [])
     properties = collapsed_properties(object_spec, swagger_spec)
-    #print(collapsed_properties.cache_info())
+    print(collapsed_properties.cache_info())
 
     result = {}
     for k, v in iteritems(object_value):

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -59,6 +59,7 @@ def unmarshal_schema_object(swagger_spec, schema_object_spec, value):
 
     if swagger_spec.config['use_models'] and \
             is_model(swagger_spec, schema_object_spec):
+        print('ttt')
         # It is important that the 'model' check comes before 'object' check.
         # Model specs also have type 'object' but also have the additional
         # MODEL_MARKER key for identification.

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -45,7 +45,7 @@ def unmarshal_schema_object(swagger_spec, schema_object_spec, value):
         deref = swagger_spec.deref
         schema_object_spec = frozendict(deref(schema_object_spec))
     #schema_object_spec = deref(schema_object_spec)
-    #print(schema_object_spec)
+    print(schema_object_spec)
     #
 
     obj_type = schema_object_spec.get('type')

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -63,7 +63,6 @@ def unmarshal_schema_object(swagger_spec, schema_object_spec, value):
         # It is important that the 'model' check comes before 'object' check.
         # Model specs also have type 'object' but also have the additional
         # MODEL_MARKER key for identification.
-        print(schema_object_spec)
         return unmarshal_model(swagger_spec, schema_object_spec, value)
 
     if obj_type == 'object':

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -42,7 +42,6 @@ def unmarshal_schema_object(swagger_spec, schema_object_spec, value):
     else:
         deref = swagger_spec.deref
     schema_object_spec = deref(schema_object_spec)
-    print(schema_object_spec)
     #print(deref.cache_info())
 
     obj_type = schema_object_spec.get('type')

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -182,7 +182,7 @@ def unmarshal_model(swagger_spec, model_spec, model_value):
     """
     #if not is_frozendict_like(model_spec) and is_dict_like(model_spec):
     #    model_spec = transform_dict_to_frozendict(model_spec)
-
+    print(model_value)
     deref = swagger_spec.fast_deref
     #print(deref.cache_info())
     model_name = deref(model_spec).get(MODEL_MARKER)

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -36,13 +36,13 @@ def unmarshal_schema_object(swagger_spec, schema_object_spec, value):
     #if not is_frozendict_like(schema_object_spec) and not is_list_like(schema_object_spec):
     #    print(type(schema_object_spec))
     #    schema_object_spec = transform_dict_to_frozendict(schema_object_spec)
-
+    print(schema_object_spec)
     if is_frozendict_like(schema_object_spec):
         deref = swagger_spec.fast_deref
     else:
         deref = swagger_spec.deref
     schema_object_spec = deref(schema_object_spec)
-    print(schema_object_spec)
+
     #print(deref.cache_info())
 
     obj_type = schema_object_spec.get('type')

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -39,6 +39,7 @@ def unmarshal_schema_object(swagger_spec, schema_object_spec, value):
 
     deref = swagger_spec.fast_deref
     schema_object_spec = deref(schema_object_spec)
+    deref.cache_info()
 
     obj_type = schema_object_spec.get('type')
 

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -37,8 +37,12 @@ def unmarshal_schema_object(swagger_spec, schema_object_spec, value):
     #    print(type(schema_object_spec))
     #    schema_object_spec = transform_dict_to_frozendict(schema_object_spec)
 
-    deref = swagger_spec.deref
+    if is_frozendict_like(schema_object_spec):
+        deref = swagger_spec.fast_deref
+    else:
+        deref = swagger_spec.deref
     schema_object_spec = deref(schema_object_spec)
+    print(schema_object_spec)
     #print(deref.cache_info())
 
     obj_type = schema_object_spec.get('type')
@@ -66,7 +70,6 @@ def unmarshal_schema_object(swagger_spec, schema_object_spec, value):
         return unmarshal_model(swagger_spec, schema_object_spec, value)
 
     if obj_type == 'object':
-        print('hi2')
         return unmarshal_object(swagger_spec, schema_object_spec, value)
 
     if obj_type == 'file':
@@ -112,7 +115,6 @@ def unmarshal_array(swagger_spec, array_spec, array_value):
             type(array_value), array_value))
 
     item_spec = swagger_spec.deref(array_spec).get('items')
-    print(item_spec)
     return [
         unmarshal_schema_object(swagger_spec, item_spec, item)
         for item in array_value

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -38,7 +38,7 @@ def unmarshal_schema_object(swagger_spec, schema_object_spec, value):
     #    schema_object_spec = transform_dict_to_frozendict(schema_object_spec)
 
     if is_frozendict_like(schema_object_spec):
-        print(schema_object_spec)
+        #print(schema_object_spec)
         deref = swagger_spec.fast_deref
     else:
         deref = swagger_spec.deref

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -174,7 +174,7 @@ def unmarshal_model(swagger_spec, model_spec, model_value):
     :rtype: Model instance
     :raises: SwaggerMappingError
     """
-    deref = swagger_spec.deref
+    deref = swagger_spec.fast_deref
     model_name = deref(model_spec).get(MODEL_MARKER)
     model_type = swagger_spec.definitions.get(model_name, None)
 

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -49,6 +49,7 @@ def unmarshal_schema_object(swagger_spec, schema_object_spec, value):
         if swagger_spec.config['default_type_to_object']:
             obj_type = 'object'
         else:
+            print('ttt')
             return value
 
     if obj_type in SWAGGER_PRIMITIVES:
@@ -59,7 +60,6 @@ def unmarshal_schema_object(swagger_spec, schema_object_spec, value):
 
     if swagger_spec.config['use_models'] and \
             is_model(swagger_spec, schema_object_spec):
-        print('ttt')
         # It is important that the 'model' check comes before 'object' check.
         # Model specs also have type 'object' but also have the additional
         # MODEL_MARKER key for identification.

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -33,7 +33,7 @@ def unmarshal_schema_object(swagger_spec, schema_object_spec, value):
     #    print(type(schema_object_spec))
     #    schema_object_spec = transform_dict_to_frozendict(schema_object_spec)
 
-
+    print(schema_object_spec)
     deref = swagger_spec.fast_deref
     schema_object_spec = deref(schema_object_spec)
     #schema_object_spec = deref(schema_object_spec)

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -45,7 +45,7 @@ def unmarshal_schema_object(swagger_spec, schema_object_spec, value):
     deref = swagger_spec.deref
     schema_object_spec = frozendict(deref(schema_object_spec))
     #schema_object_spec = deref(schema_object_spec)
-    print(schema_object_spec)
+    #print(schema_object_spec)
     #
 
     obj_type = schema_object_spec.get('type')

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -37,15 +37,15 @@ def unmarshal_schema_object(swagger_spec, schema_object_spec, value):
     #    print(type(schema_object_spec))
     #    schema_object_spec = transform_dict_to_frozendict(schema_object_spec)
 
-    if is_frozendict_like(schema_object_spec):
-        deref = swagger_spec.fast_deref
-        schema_object_spec = deref(schema_object_spec)
+    #if is_frozendict_like(schema_object_spec):
+    #    deref = swagger_spec.fast_deref
+    #    schema_object_spec = deref(schema_object_spec)
         #print(deref.cache_info())
-    else:
-        deref = swagger_spec.deref
-        schema_object_spec = frozendict(deref(schema_object_spec))
+    #else:
+    deref = swagger_spec.deref
+    schema_object_spec = frozendict(deref(schema_object_spec))
     #schema_object_spec = deref(schema_object_spec)
-    #print(schema_object_spec)
+    print(schema_object_spec)
     #
 
     obj_type = schema_object_spec.get('type')

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -41,7 +41,7 @@ def unmarshal_schema_object(swagger_spec, schema_object_spec, value):
         deref = swagger_spec.fast_deref
     else:
         deref = swagger_spec.deref
-    print(schema_object_spec)
+    #print(schema_object_spec)
     schema_object_spec = deref(schema_object_spec)
     #print(deref.cache_info())
 

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -41,7 +41,6 @@ def unmarshal_schema_object(swagger_spec, schema_object_spec, value):
         deref = swagger_spec.fast_deref
     else:
         deref = swagger_spec.deref
-    deref = swagger_spec.deref
     schema_object_spec = deref(schema_object_spec)
     #print(deref.cache_info())
 

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -151,7 +151,6 @@ def unmarshal_object(swagger_spec, object_spec, object_value):
             result[k] = unmarshal_schema_object(swagger_spec, prop_spec, v)
         else:
             # Don't marshal when a spec is not available - just pass through
-            print(v)
             result[k] = v
 
     for prop_name, prop_spec in iteritems(properties):

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -134,6 +134,7 @@ def unmarshal_object(swagger_spec, object_spec, object_value):
     :raises: SwaggerMappingError
     """
     deref = swagger_spec.fast_deref
+    print(object_spec)
 
     if object_value is None:
         return handle_null_value(swagger_spec, object_spec)
@@ -214,7 +215,7 @@ def unmarshal_model(swagger_spec, model_spec, model_value):
             )
         model_type = swagger_spec.definitions.get(child_model_name)
         model_spec = model_type._model_spec
-    print(model_spec)
+
     model_as_dict = unmarshal_object(swagger_spec, model_spec, model_value)
     model_instance = model_type._from_dict(model_as_dict)
     return model_instance

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -111,7 +111,8 @@ def unmarshal_array(swagger_spec, array_spec, array_value):
         raise SwaggerMappingError('Expected list like type for {0}:{1}'.format(
             type(array_value), array_value))
 
-    item_spec = transform_dict_to_frozendict(swagger_spec.deref(array_spec).get('items'))
+    item_spec = swagger_spec.deref(array_spec).get('items')
+    print(item_spec)
     return [
         unmarshal_schema_object(swagger_spec, item_spec, item)
         for item in array_value

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -114,7 +114,7 @@ def unmarshal_array(swagger_spec, array_spec, array_value):
         raise SwaggerMappingError('Expected list like type for {0}:{1}'.format(
             type(array_value), array_value))
 
-    item_spec = transform_dict_to_frozendict(swagger_spec.deref(array_spec).get('items'))
+    item_spec = swagger_spec.fast_deref(array_spec).get('items')
     return [
         unmarshal_schema_object(swagger_spec, item_spec, item)
         for item in array_value

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -38,11 +38,11 @@ def unmarshal_schema_object(swagger_spec, schema_object_spec, value):
     #    schema_object_spec = transform_dict_to_frozendict(schema_object_spec)
 
     if is_frozendict_like(schema_object_spec):
-        print(schema_object_spec)
         deref = swagger_spec.fast_deref
     else:
         deref = swagger_spec.deref
     schema_object_spec = deref(schema_object_spec)
+    print(schema_object_spec)
     #print(deref.cache_info())
 
     obj_type = schema_object_spec.get('type')

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -142,13 +142,13 @@ def unmarshal_object(swagger_spec, object_spec, object_value):
     for k, v in iteritems(object_value):
         prop_spec = get_spec_for_prop(
             swagger_spec, object_spec, object_value, k, properties)
+        print(type(prop_spec))
         if v is None and k not in required_fields and prop_spec:
             if schema.has_default(swagger_spec, prop_spec):
                 result[k] = schema.get_default(swagger_spec, prop_spec)
             else:
                 result[k] = None
         elif prop_spec:
-            print(type(prop_spec))
             result[k] = unmarshal_schema_object(swagger_spec, prop_spec, v)
         else:
             # Don't marshal when a spec is not available - just pass through

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -29,16 +29,9 @@ def unmarshal_schema_object(swagger_spec, schema_object_spec, value):
     :rtype: int, float, long, string, unicode, boolean, list, dict, object (in
         the case of a 'format' conversion', or Model type
     """
-    #if not is_frozendict_like(schema_object_spec) and not is_list_like(schema_object_spec):
-    #    print(type(schema_object_spec))
-    #    schema_object_spec = transform_dict_to_frozendict(schema_object_spec)
 
-    #print(schema_object_spec)
     deref = swagger_spec.fast_deref
     schema_object_spec = deref(schema_object_spec)
-    #schema_object_spec = deref(schema_object_spec)
-    #print(schema_object_spec)
-    #
 
     obj_type = schema_object_spec.get('type')
 
@@ -172,10 +165,8 @@ def unmarshal_model(swagger_spec, model_spec, model_value):
     :rtype: Model instance
     :raises: SwaggerMappingError
     """
-    #if not is_frozendict_like(model_spec) and is_dict_like(model_spec):
-    #    model_spec = transform_dict_to_frozendict(model_spec)
+
     deref = swagger_spec.fast_deref
-    #print(deref.cache_info())
     model_name = deref(model_spec).get(MODEL_MARKER)
 
     model_type = swagger_spec.definitions.get(model_name, None)
@@ -197,7 +188,6 @@ def unmarshal_model(swagger_spec, model_spec, model_value):
     # Check if model is polymorphic
     discriminator = model_spec.get('discriminator')
     if discriminator is not None:
-        #print('ttt')
         child_model_name = model_value.get(discriminator, None)
         if child_model_name not in swagger_spec.definitions:
             raise SwaggerMappingError(

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -34,6 +34,7 @@ def unmarshal_schema_object(swagger_spec, schema_object_spec, value):
         the case of a 'format' conversion', or Model type
     """
     if not is_frozendict_like(schema_object_spec) and not is_list_like(schema_object_spec):
+        print(type(schema_object_spec))
         schema_object_spec = transform_dict_to_frozendict(schema_object_spec)
 
     deref = swagger_spec.fast_deref
@@ -136,7 +137,6 @@ def unmarshal_object(swagger_spec, object_spec, object_value):
     object_spec = deref(object_spec)
     required_fields = object_spec.get('required', [])
     properties = collapsed_properties(object_spec, swagger_spec)
-    print(properties)
 
     result = {}
     for k, v in iteritems(object_value):

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -157,7 +157,6 @@ def unmarshal_object(swagger_spec, object_spec, object_value):
             else:
                 result[k] = None
         elif prop_spec:
-            print(prop_spec)
             result[k] = unmarshal_schema_object(swagger_spec, prop_spec, v)
         else:
             # Don't marshal when a spec is not available - just pass through
@@ -206,6 +205,7 @@ def unmarshal_model(swagger_spec, model_spec, model_value):
     # Check if model is polymorphic
     discriminator = model_spec.get('discriminator')
     if discriminator is not None:
+        print('ttt')
         child_model_name = model_value.get(discriminator, None)
         if child_model_name not in swagger_spec.definitions:
             raise SwaggerMappingError(

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -43,7 +43,6 @@ def unmarshal_schema_object(swagger_spec, schema_object_spec, value):
         #print(deref.cache_info())
     else:
         deref = swagger_spec.deref
-        print(schema_object_spec)
         schema_object_spec = frozendict(deref(schema_object_spec))
     #schema_object_spec = deref(schema_object_spec)
     #print(schema_object_spec)

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -150,7 +150,6 @@ def unmarshal_object(swagger_spec, object_spec, object_value):
             else:
                 result[k] = None
         elif prop_spec:
-            print(prop_spec)
             result[k] = unmarshal_schema_object(swagger_spec, prop_spec, v)
         else:
             # Don't marshal when a spec is not available - just pass through

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -42,7 +42,7 @@ def unmarshal_schema_object(swagger_spec, schema_object_spec, value):
     else:
         deref = swagger_spec.deref
     schema_object_spec = deref(schema_object_spec)
-    print(schema_object_spec)
+    #print(schema_object_spec)
     #print(deref.cache_info())
 
     obj_type = schema_object_spec.get('type')

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -139,7 +139,7 @@ def unmarshal_object(swagger_spec, object_spec, object_value):
     object_spec = deref(object_spec)
     required_fields = object_spec.get('required', [])
     properties = collapsed_properties(object_spec, swagger_spec)
-    print(collapsed_properties.cache_info())
+    #print(collapsed_properties.cache_info())
 
     result = {}
     for k, v in iteritems(object_value):

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -38,7 +38,7 @@ def unmarshal_schema_object(swagger_spec, schema_object_spec, value):
     #    schema_object_spec = transform_dict_to_frozendict(schema_object_spec)
 
     if is_frozendict_like(schema_object_spec):
-        #print(schema_object_spec)
+        print(schema_object_spec)
         deref = swagger_spec.fast_deref
     else:
         deref = swagger_spec.deref

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -181,7 +181,7 @@ def unmarshal_model(swagger_spec, model_spec, model_value):
     #if not is_frozendict_like(model_spec) and is_dict_like(model_spec):
     #    model_spec = transform_dict_to_frozendict(model_spec)
     if not is_frozendict_like(model_spec):
-        frozendict(model_spec)
+        model_spec = frozendict(model_spec)
     deref = swagger_spec.fast_deref
     #print(deref.cache_info())
     model_name = deref(model_spec).get(MODEL_MARKER)

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -40,7 +40,6 @@ def unmarshal_schema_object(swagger_spec, schema_object_spec, value):
     if is_frozendict_like(schema_object_spec):
         deref = swagger_spec.fast_deref
         schema_object_spec = deref(schema_object_spec)
-        print(schema_object_spec)
     else:
         deref = swagger_spec.deref
         schema_object_spec = frozendict(deref(schema_object_spec))

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -37,7 +37,7 @@ def unmarshal_schema_object(swagger_spec, schema_object_spec, value):
     deref = swagger_spec.fast_deref
     schema_object_spec = deref(schema_object_spec)
     #schema_object_spec = deref(schema_object_spec)
-    #print(schema_object_spec)
+    print(schema_object_spec)
     #
 
     obj_type = schema_object_spec.get('type')
@@ -174,7 +174,6 @@ def unmarshal_model(swagger_spec, model_spec, model_value):
     """
     #if not is_frozendict_like(model_spec) and is_dict_like(model_spec):
     #    model_spec = transform_dict_to_frozendict(model_spec)
-    print('ttt')
     deref = swagger_spec.fast_deref
     #print(deref.cache_info())
     model_name = deref(model_spec).get(MODEL_MARKER)

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -101,6 +101,7 @@ def unmarshal_array(swagger_spec, array_spec, array_value):
     :rtype: list
     :raises: SwaggerMappingError
     """
+    print(array_spec)
     if array_value is None:
         return handle_null_value(swagger_spec, array_spec)
 
@@ -135,7 +136,6 @@ def unmarshal_object(swagger_spec, object_spec, object_value):
 
     object_spec = deref(object_spec)
     required_fields = object_spec.get('required', [])
-    print(object_spec)
     properties = collapsed_properties(object_spec, swagger_spec)
 
     result = {}

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -138,7 +138,6 @@ def unmarshal_object(swagger_spec, object_spec, object_value):
     object_spec = deref(object_spec)
     required_fields = object_spec.get('required', [])
     properties = collapsed_properties(object_spec, swagger_spec)
-    print(properties)
 
     result = {}
     for k, v in iteritems(object_value):

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -33,11 +33,11 @@ def unmarshal_schema_object(swagger_spec, schema_object_spec, value):
     :rtype: int, float, long, string, unicode, boolean, list, dict, object (in
         the case of a 'format' conversion', or Model type
     """
-    if not is_frozendict_like(schema_object_spec) and not is_list_like(schema_object_spec):
-        print(type(schema_object_spec))
-        schema_object_spec = transform_dict_to_frozendict(schema_object_spec)
+    #if not is_frozendict_like(schema_object_spec) and not is_list_like(schema_object_spec):
+    #    print(type(schema_object_spec))
+    #    schema_object_spec = transform_dict_to_frozendict(schema_object_spec)
 
-    deref = swagger_spec.fast_deref
+    deref = swagger_spec.deref
     schema_object_spec = deref(schema_object_spec)
     #print(deref.cache_info())
 

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -145,7 +145,7 @@ def unmarshal_object(swagger_spec, object_spec, object_value):
     object_spec = deref(object_spec)
     required_fields = object_spec.get('required', [])
     properties = collapsed_properties(object_spec, swagger_spec)
-    print(collapsed_properties.cache_info())
+    #print(collapsed_properties.cache_info())
 
     result = {}
     for k, v in iteritems(object_value):

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -16,11 +16,6 @@ from bravado_core.schema import is_list_like
 from bravado_core.schema import SWAGGER_PRIMITIVES
 from frozendict import frozendict
 
-def unmarshal(swagger_spec, schema_object_spec, value):
-    deref = swagger_spec.deref
-    schema_object_spec = frozendict(deref(schema_object_spec))
-    return unmarshal_schema_object(swagger_spec, schema_object_spec, value)
-
 def unmarshal_schema_object(swagger_spec, schema_object_spec, value):
     """Unmarshal the value using the given schema object specification.
 
@@ -41,13 +36,13 @@ def unmarshal_schema_object(swagger_spec, schema_object_spec, value):
     #    print(type(schema_object_spec))
     #    schema_object_spec = transform_dict_to_frozendict(schema_object_spec)
 
-    #if is_frozendict_like(schema_object_spec):
-    deref = swagger_spec.fast_deref
-    schema_object_spec = deref(schema_object_spec)
+    if is_frozendict_like(schema_object_spec):
+        deref = swagger_spec.fast_deref
+        schema_object_spec = deref(schema_object_spec)
         #print(deref.cache_info())
-    #else:
-    #    deref = swagger_spec.deref
-    #    schema_object_spec = frozendict(deref(schema_object_spec))
+    else:
+        deref = swagger_spec.deref
+        schema_object_spec = frozendict(deref(schema_object_spec))
     #schema_object_spec = deref(schema_object_spec)
     #print(schema_object_spec)
     #

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -135,6 +135,7 @@ def unmarshal_object(swagger_spec, object_spec, object_value):
 
     object_spec = deref(object_spec)
     required_fields = object_spec.get('required', [])
+    print(object_spec)
     properties = collapsed_properties(object_spec, swagger_spec)
 
     result = {}
@@ -201,7 +202,6 @@ def unmarshal_model(swagger_spec, model_spec, model_value):
         model_type = swagger_spec.definitions.get(child_model_name)
         model_spec = model_type._model_spec
 
-    print(model_spec)
     model_as_dict = unmarshal_object(swagger_spec, model_spec, model_value)
     model_instance = model_type._from_dict(model_as_dict)
     return model_instance

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -40,7 +40,6 @@ def unmarshal_schema_object(swagger_spec, schema_object_spec, value):
     deref = swagger_spec.deref
     schema_object_spec = deref(schema_object_spec)
     #print(deref.cache_info())
-    print('start')
 
     obj_type = schema_object_spec.get('type')
 
@@ -174,7 +173,6 @@ def unmarshal_model(swagger_spec, model_spec, model_value):
     :rtype: Model instance
     :raises: SwaggerMappingError
     """
-    print(model_spec)
     if is_dict_like(model_spec):
         model_spec = transform_dict_to_frozendict(model_spec)
     deref = swagger_spec.fast_deref

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -37,13 +37,13 @@ def unmarshal_schema_object(swagger_spec, schema_object_spec, value):
     #    print(type(schema_object_spec))
     #    schema_object_spec = transform_dict_to_frozendict(schema_object_spec)
 
-    if is_frozendict_like(schema_object_spec):
-        deref = swagger_spec.fast_deref
-        schema_object_spec = deref(schema_object_spec)
+    #if is_frozendict_like(schema_object_spec):
+    deref = swagger_spec.fast_deref
+    schema_object_spec = deref(schema_object_spec)
         #print(deref.cache_info())
-    else:
-        deref = swagger_spec.deref
-        schema_object_spec = frozendict(deref(schema_object_spec))
+    #else:
+    #    deref = swagger_spec.deref
+    #    schema_object_spec = frozendict(deref(schema_object_spec))
     #schema_object_spec = deref(schema_object_spec)
     #print(schema_object_spec)
     #

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -37,7 +37,7 @@ def unmarshal_schema_object(swagger_spec, schema_object_spec, value):
     deref = swagger_spec.fast_deref
     schema_object_spec = deref(schema_object_spec)
     #schema_object_spec = deref(schema_object_spec)
-    print(schema_object_spec)
+    #print(schema_object_spec)
     #
 
     obj_type = schema_object_spec.get('type')

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -176,7 +176,9 @@ def unmarshal_model(swagger_spec, model_spec, model_value):
     if is_dict_like(model_spec):
         model_spec = transform_dict_to_frozendict(model_spec)
     deref = swagger_spec.fast_deref
+    print(deref.cache_info())
     model_name = deref(model_spec).get(MODEL_MARKER)
+
     model_type = swagger_spec.definitions.get(model_name, None)
 
     if model_type is None:

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -110,9 +110,8 @@ def unmarshal_array(swagger_spec, array_spec, array_value):
             type(array_value), array_value))
 
     item_spec = swagger_spec.fast_deref(array_spec).get('items')
-    item_spec = swagger_spec.fast_deref(item_spec)
     return [
-        unmarshal_model(swagger_spec, item_spec, item)
+        unmarshal_schema_object(swagger_spec, item_spec, item)
         for item in array_value
     ]
 

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -182,7 +182,6 @@ def unmarshal_model(swagger_spec, model_spec, model_value):
     """
     #if not is_frozendict_like(model_spec) and is_dict_like(model_spec):
     #    model_spec = transform_dict_to_frozendict(model_spec)
-    print(model_value)
     deref = swagger_spec.fast_deref
     #print(deref.cache_info())
     model_name = deref(model_spec).get(MODEL_MARKER)

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -114,7 +114,7 @@ def unmarshal_array(swagger_spec, array_spec, array_value):
         raise SwaggerMappingError('Expected list like type for {0}:{1}'.format(
             type(array_value), array_value))
 
-    item_spec = swagger_spec.deref(array_spec).get('items')
+    item_spec = transform_dict_to_frozendict(swagger_spec.deref(array_spec).get('items'))
     return [
         unmarshal_schema_object(swagger_spec, item_spec, item)
         for item in array_value

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -40,6 +40,7 @@ def unmarshal_schema_object(swagger_spec, schema_object_spec, value):
     if is_frozendict_like(schema_object_spec):
         deref = swagger_spec.fast_deref
         schema_object_spec = deref(schema_object_spec)
+        print(schema_object_spec)
     else:
         deref = swagger_spec.deref
         schema_object_spec = frozendict(deref(schema_object_spec))

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -37,15 +37,15 @@ def unmarshal_schema_object(swagger_spec, schema_object_spec, value):
     #    print(type(schema_object_spec))
     #    schema_object_spec = transform_dict_to_frozendict(schema_object_spec)
 
-    #if is_frozendict_like(schema_object_spec):
-    #    deref = swagger_spec.fast_deref
-    #    schema_object_spec = deref(schema_object_spec)
+    if is_frozendict_like(schema_object_spec):
+        deref = swagger_spec.fast_deref
+        schema_object_spec = deref(schema_object_spec)
         #print(deref.cache_info())
-    #else:
-    deref = swagger_spec.deref
-    schema_object_spec = frozendict(deref(schema_object_spec))
+    else:
+        deref = swagger_spec.deref
+        schema_object_spec = frozendict(deref(schema_object_spec))
     #schema_object_spec = deref(schema_object_spec)
-    #print(schema_object_spec)
+    print(schema_object_spec)
     #
 
     obj_type = schema_object_spec.get('type')
@@ -215,6 +215,7 @@ def unmarshal_model(swagger_spec, model_spec, model_value):
             )
         model_type = swagger_spec.definitions.get(child_model_name)
         model_spec = model_type._model_spec
+        print(type(model_spec))
 
     model_as_dict = unmarshal_object(swagger_spec, model_spec, model_value)
     model_instance = model_type._from_dict(model_as_dict)

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -111,7 +111,6 @@ def unmarshal_array(swagger_spec, array_spec, array_value):
             type(array_value), array_value))
 
     item_spec = swagger_spec.deref(array_spec).get('items')
-    print(item_spec)
     return [
         unmarshal_schema_object(swagger_spec, item_spec, item)
         for item in array_value
@@ -150,6 +149,7 @@ def unmarshal_object(swagger_spec, object_spec, object_value):
             else:
                 result[k] = None
         elif prop_spec:
+            print(prop_spec)
             result[k] = unmarshal_schema_object(swagger_spec, prop_spec, v)
         else:
             # Don't marshal when a spec is not available - just pass through

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -150,7 +150,7 @@ def unmarshal_object(swagger_spec, object_spec, object_value):
     result = {}
     for k, v in iteritems(object_value):
         prop_spec = get_spec_for_prop(
-            swagger_spec, object_spec, object_value, k, properties)
+            swagger_spec, object_spec, k, properties)
         if v is None and k not in required_fields and prop_spec:
             if schema.has_default(swagger_spec, prop_spec):
                 result[k] = schema.get_default(swagger_spec, prop_spec)

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -141,7 +141,7 @@ def unmarshal_object(swagger_spec, object_spec, object_value):
     object_spec = deref(object_spec)
     required_fields = object_spec.get('required', [])
     properties = collapsed_properties(object_spec, swagger_spec)
-    print(collapsed_properties.cache_info())
+    #print(collapsed_properties.cache_info())
 
     result = {}
     for k, v in iteritems(object_value):

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -139,6 +139,7 @@ def unmarshal_object(swagger_spec, object_spec, object_value):
     object_spec = deref(object_spec)
     required_fields = object_spec.get('required', [])
     properties = collapsed_properties(object_spec, swagger_spec)
+    print(collapsed_properties.cache_info())
 
     result = {}
     for k, v in iteritems(object_value):

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -37,13 +37,13 @@ def unmarshal_schema_object(swagger_spec, schema_object_spec, value):
     #    print(type(schema_object_spec))
     #    schema_object_spec = transform_dict_to_frozendict(schema_object_spec)
 
-    #if is_frozendict_like(schema_object_spec):
-    #    deref = swagger_spec.fast_deref
-    #    schema_object_spec = deref(schema_object_spec)
+    if is_frozendict_like(schema_object_spec):
+        deref = swagger_spec.fast_deref
+        schema_object_spec = deref(schema_object_spec)
         #print(deref.cache_info())
-    #else:
-    deref = swagger_spec.deref
-    schema_object_spec = frozendict(deref(schema_object_spec))
+    else:
+        deref = swagger_spec.deref
+        schema_object_spec = frozendict(deref(schema_object_spec))
     #schema_object_spec = deref(schema_object_spec)
     #print(schema_object_spec)
     #
@@ -117,7 +117,7 @@ def unmarshal_array(swagger_spec, array_spec, array_value):
         raise SwaggerMappingError('Expected list like type for {0}:{1}'.format(
             type(array_value), array_value))
 
-    item_spec = frozendict(swagger_spec.deref(array_spec)).get('items')
+    item_spec = swagger_spec.fast_deref(array_spec).get('items')
     return [
         unmarshal_schema_object(swagger_spec, item_spec, item)
         for item in array_value
@@ -133,7 +133,7 @@ def unmarshal_object(swagger_spec, object_spec, object_value):
     :rtype: dict
     :raises: SwaggerMappingError
     """
-    deref = swagger_spec.deref
+    deref = swagger_spec.fast_deref
 
     if object_value is None:
         return handle_null_value(swagger_spec, object_spec)
@@ -142,7 +142,7 @@ def unmarshal_object(swagger_spec, object_spec, object_value):
         raise SwaggerMappingError('Expected dict like type for {0}:{1}'.format(
             type(object_value), object_value))
 
-    object_spec = frozendict(deref(object_spec))
+    object_spec = deref(object_spec)
     required_fields = object_spec.get('required', [])
     properties = collapsed_properties(object_spec, swagger_spec)
     #print(collapsed_properties.cache_info())
@@ -182,7 +182,7 @@ def unmarshal_model(swagger_spec, model_spec, model_value):
     """
     #if not is_frozendict_like(model_spec) and is_dict_like(model_spec):
     #    model_spec = transform_dict_to_frozendict(model_spec)
-    deref = swagger_spec.deref
+    deref = swagger_spec.fast_deref
     #print(deref.cache_info())
     model_name = deref(model_spec).get(MODEL_MARKER)
 

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -9,12 +9,9 @@ from bravado_core.model import MODEL_MARKER
 from bravado_core.schema import collapsed_properties
 from bravado_core.schema import get_spec_for_prop
 from bravado_core.schema import handle_null_value
-from bravado_core.schema import is_frozendict_like
 from bravado_core.schema import is_dict_like
-from bravado_core.schema import transform_dict_to_frozendict
 from bravado_core.schema import is_list_like
 from bravado_core.schema import SWAGGER_PRIMITIVES
-from frozendict import frozendict
 
 def unmarshal_schema_object(swagger_spec, schema_object_spec, value):
     """Unmarshal the value using the given schema object specification.
@@ -36,13 +33,9 @@ def unmarshal_schema_object(swagger_spec, schema_object_spec, value):
     #    print(type(schema_object_spec))
     #    schema_object_spec = transform_dict_to_frozendict(schema_object_spec)
 
-    if is_frozendict_like(schema_object_spec):
-        deref = swagger_spec.fast_deref
-        schema_object_spec = deref(schema_object_spec)
-        #print(deref.cache_info())
-    else:
-        deref = swagger_spec.deref
-        schema_object_spec = frozendict(deref(schema_object_spec))
+
+    deref = swagger_spec.deref
+    schema_object_spec = deref(schema_object_spec)
     #schema_object_spec = deref(schema_object_spec)
     #print(schema_object_spec)
     #
@@ -116,7 +109,7 @@ def unmarshal_array(swagger_spec, array_spec, array_value):
         raise SwaggerMappingError('Expected list like type for {0}:{1}'.format(
             type(array_value), array_value))
 
-    item_spec = swagger_spec.fast_deref(array_spec).get('items')
+    item_spec = swagger_spec.deref(array_spec).get('items')
     return [
         unmarshal_schema_object(swagger_spec, item_spec, item)
         for item in array_value
@@ -132,7 +125,7 @@ def unmarshal_object(swagger_spec, object_spec, object_value):
     :rtype: dict
     :raises: SwaggerMappingError
     """
-    deref = swagger_spec.fast_deref
+    deref = swagger_spec.deref
 
     if object_value is None:
         return handle_null_value(swagger_spec, object_spec)
@@ -181,7 +174,7 @@ def unmarshal_model(swagger_spec, model_spec, model_value):
     """
     #if not is_frozendict_like(model_spec) and is_dict_like(model_spec):
     #    model_spec = transform_dict_to_frozendict(model_spec)
-    deref = swagger_spec.fast_deref
+    deref = swagger_spec.deref
     #print(deref.cache_info())
     model_name = deref(model_spec).get(MODEL_MARKER)
 

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -42,7 +42,6 @@ def unmarshal_schema_object(swagger_spec, schema_object_spec, value):
     else:
         deref = swagger_spec.deref
     deref = swagger_spec.deref
-    print(schema_object_spec)
     schema_object_spec = deref(schema_object_spec)
     #print(deref.cache_info())
 

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -182,6 +182,7 @@ def unmarshal_model(swagger_spec, model_spec, model_value):
     """
     #if not is_frozendict_like(model_spec) and is_dict_like(model_spec):
     #    model_spec = transform_dict_to_frozendict(model_spec)
+    print(model_spec)
     deref = swagger_spec.fast_deref
     #print(deref.cache_info())
     model_name = deref(model_spec).get(MODEL_MARKER)
@@ -205,7 +206,7 @@ def unmarshal_model(swagger_spec, model_spec, model_value):
     # Check if model is polymorphic
     discriminator = model_spec.get('discriminator')
     if discriminator is not None:
-        print('ttt')
+        #print('ttt')
         child_model_name = model_value.get(discriminator, None)
         if child_model_name not in swagger_spec.definitions:
             raise SwaggerMappingError(

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -40,12 +40,13 @@ def unmarshal_schema_object(swagger_spec, schema_object_spec, value):
     if is_frozendict_like(schema_object_spec):
         deref = swagger_spec.fast_deref
         schema_object_spec = deref(schema_object_spec)
+        print(deref.cache_info())
     else:
         deref = swagger_spec.deref
         schema_object_spec = frozendict(deref(schema_object_spec))
     #schema_object_spec = deref(schema_object_spec)
     #print(schema_object_spec)
-    #print(deref.cache_info())
+    #
 
     obj_type = schema_object_spec.get('type')
 

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -45,7 +45,7 @@ def unmarshal_schema_object(swagger_spec, schema_object_spec, value):
         deref = swagger_spec.deref
         schema_object_spec = frozendict(deref(schema_object_spec))
     #schema_object_spec = deref(schema_object_spec)
-    print(schema_object_spec)
+    #print(schema_object_spec)
     #
 
     obj_type = schema_object_spec.get('type')
@@ -118,6 +118,7 @@ def unmarshal_array(swagger_spec, array_spec, array_value):
             type(array_value), array_value))
 
     item_spec = swagger_spec.fast_deref(array_spec).get('items')
+    print(item_spec)
     return [
         unmarshal_schema_object(swagger_spec, item_spec, item)
         for item in array_value

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -179,7 +179,6 @@ def unmarshal_model(swagger_spec, model_spec, model_value):
     #if not is_frozendict_like(model_spec) and is_dict_like(model_spec):
     #    model_spec = transform_dict_to_frozendict(model_spec)
     if not is_frozendict_like(model_spec):
-        print('ttt')
         model_spec = frozendict(model_spec)
     deref = swagger_spec.fast_deref
     #print(deref.cache_info())

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -63,7 +63,7 @@ def unmarshal_schema_object(swagger_spec, schema_object_spec, value):
         # It is important that the 'model' check comes before 'object' check.
         # Model specs also have type 'object' but also have the additional
         # MODEL_MARKER key for identification.
-        print('hi')
+        print(schema_object_spec)
         return unmarshal_model(swagger_spec, schema_object_spec, value)
 
     if obj_type == 'object':

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -41,6 +41,7 @@ def unmarshal_schema_object(swagger_spec, schema_object_spec, value):
         deref = swagger_spec.fast_deref
     else:
         deref = swagger_spec.deref
+    deref = swagger_spec.deref
     print(schema_object_spec)
     schema_object_spec = deref(schema_object_spec)
     #print(deref.cache_info())
@@ -177,8 +178,10 @@ def unmarshal_model(swagger_spec, model_spec, model_value):
     :rtype: Model instance
     :raises: SwaggerMappingError
     """
-    if not is_frozendict_like(model_spec) and is_dict_like(model_spec):
-        model_spec = transform_dict_to_frozendict(model_spec)
+    #if not is_frozendict_like(model_spec) and is_dict_like(model_spec):
+    #    model_spec = transform_dict_to_frozendict(model_spec)
+    if not is_frozendict_like(model_spec):
+        frozendict(model_spec)
     deref = swagger_spec.fast_deref
     #print(deref.cache_info())
     model_name = deref(model_spec).get(MODEL_MARKER)

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -37,13 +37,13 @@ def unmarshal_schema_object(swagger_spec, schema_object_spec, value):
     #    print(type(schema_object_spec))
     #    schema_object_spec = transform_dict_to_frozendict(schema_object_spec)
 
-    if is_frozendict_like(schema_object_spec):
-        deref = swagger_spec.fast_deref
-        schema_object_spec = deref(schema_object_spec)
+    #if is_frozendict_like(schema_object_spec):
+    #    deref = swagger_spec.fast_deref
+    #    schema_object_spec = deref(schema_object_spec)
         #print(deref.cache_info())
-    else:
-        deref = swagger_spec.deref
-        schema_object_spec = frozendict(deref(schema_object_spec))
+    #else:
+    deref = swagger_spec.deref
+    schema_object_spec = frozendict(deref(schema_object_spec))
     #schema_object_spec = deref(schema_object_spec)
     #print(schema_object_spec)
     #
@@ -117,7 +117,6 @@ def unmarshal_array(swagger_spec, array_spec, array_value):
         raise SwaggerMappingError('Expected list like type for {0}:{1}'.format(
             type(array_value), array_value))
 
-    print(array_spec)
     item_spec = swagger_spec.fast_deref(array_spec).get('items')
     return [
         unmarshal_schema_object(swagger_spec, item_spec, item)

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -34,12 +34,12 @@ def unmarshal_schema_object(swagger_spec, schema_object_spec, value):
         the case of a 'format' conversion', or Model type
     """
     if not is_frozendict_like(schema_object_spec) and not is_list_like(schema_object_spec):
-        print(type(schema_object_spec))
+        #print(type(schema_object_spec))
         schema_object_spec = transform_dict_to_frozendict(schema_object_spec)
 
     deref = swagger_spec.fast_deref
     schema_object_spec = deref(schema_object_spec)
-    print(deref.cache_info())
+    #print(deref.cache_info())
 
     obj_type = schema_object_spec.get('type')
 
@@ -111,6 +111,7 @@ def unmarshal_array(swagger_spec, array_spec, array_value):
             type(array_value), array_value))
 
     item_spec = swagger_spec.deref(array_spec).get('items')
+    print(item_spec)
     return [
         unmarshal_schema_object(swagger_spec, item_spec, item)
         for item in array_value

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -37,7 +37,7 @@ def unmarshal_schema_object(swagger_spec, schema_object_spec, value):
     deref = swagger_spec.fast_deref
     schema_object_spec = deref(schema_object_spec)
     #schema_object_spec = deref(schema_object_spec)
-    #print(schema_object_spec)
+    print(schema_object_spec)
     #
 
     obj_type = schema_object_spec.get('type')
@@ -49,7 +49,6 @@ def unmarshal_schema_object(swagger_spec, schema_object_spec, value):
         if swagger_spec.config['default_type_to_object']:
             obj_type = 'object'
         else:
-            print('ttt')
             return value
 
     if obj_type in SWAGGER_PRIMITIVES:

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -36,6 +36,7 @@ def unmarshal_schema_object(swagger_spec, schema_object_spec, value):
     if not is_frozendict_like(schema_object_spec) and not is_list_like(schema_object_spec):
         #print(type(schema_object_spec))
         schema_object_spec = transform_dict_to_frozendict(schema_object_spec)
+        print(schema_object_spec)
 
     deref = swagger_spec.fast_deref
     schema_object_spec = deref(schema_object_spec)

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -174,6 +174,7 @@ def unmarshal_model(swagger_spec, model_spec, model_value):
     """
     #if not is_frozendict_like(model_spec) and is_dict_like(model_spec):
     #    model_spec = transform_dict_to_frozendict(model_spec)
+    print('ttt')
     deref = swagger_spec.fast_deref
     #print(deref.cache_info())
     model_name = deref(model_spec).get(MODEL_MARKER)

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -39,9 +39,11 @@ def unmarshal_schema_object(swagger_spec, schema_object_spec, value):
 
     if is_frozendict_like(schema_object_spec):
         deref = swagger_spec.fast_deref
+        schema_object_spec = deref(schema_object_spec)
     else:
         deref = swagger_spec.deref
-    schema_object_spec = deref(schema_object_spec)
+        schema_object_spec = frozendict(deref(schema_object_spec))
+    #schema_object_spec = deref(schema_object_spec)
     #print(schema_object_spec)
     #print(deref.cache_info())
 
@@ -179,8 +181,7 @@ def unmarshal_model(swagger_spec, model_spec, model_value):
     """
     #if not is_frozendict_like(model_spec) and is_dict_like(model_spec):
     #    model_spec = transform_dict_to_frozendict(model_spec)
-    if not is_frozendict_like(model_spec):
-        model_spec = transform_dict_to_frozendict(model_spec)
+
     deref = swagger_spec.fast_deref
     #print(deref.cache_info())
     model_name = deref(model_spec).get(MODEL_MARKER)

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -45,7 +45,7 @@ def unmarshal_schema_object(swagger_spec, schema_object_spec, value):
         deref = swagger_spec.deref
         schema_object_spec = frozendict(deref(schema_object_spec))
     #schema_object_spec = deref(schema_object_spec)
-    print(schema_object_spec)
+    #print(schema_object_spec)
     #
 
     obj_type = schema_object_spec.get('type')

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -177,7 +177,7 @@ def unmarshal_model(swagger_spec, model_spec, model_value):
     :rtype: Model instance
     :raises: SwaggerMappingError
     """
-    if is_dict_like(model_spec):
+    if not is_frozendict_like(model_spec) and is_dict_like(model_spec):
         model_spec = transform_dict_to_frozendict(model_spec)
     deref = swagger_spec.fast_deref
     #print(deref.cache_info())

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -110,8 +110,9 @@ def unmarshal_array(swagger_spec, array_spec, array_value):
             type(array_value), array_value))
 
     item_spec = swagger_spec.fast_deref(array_spec).get('items')
+    item_spec = swagger_spec.fast_deref(item_spec)
     return [
-        unmarshal_schema_object(swagger_spec, item_spec, item)
+        unmarshal_model(swagger_spec, item_spec, item)
         for item in array_value
     ]
 

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -180,6 +180,7 @@ def unmarshal_model(swagger_spec, model_spec, model_value):
     #if not is_frozendict_like(model_spec) and is_dict_like(model_spec):
     #    model_spec = transform_dict_to_frozendict(model_spec)
     if not is_frozendict_like(model_spec):
+        print('ttt')
         model_spec = frozendict(model_spec)
     deref = swagger_spec.fast_deref
     #print(deref.cache_info())

--- a/bravado_core/unmarshal.py
+++ b/bravado_core/unmarshal.py
@@ -173,6 +173,7 @@ def unmarshal_model(swagger_spec, model_spec, model_value):
     :rtype: Model instance
     :raises: SwaggerMappingError
     """
+    print(model_spec)
     if is_dict_like(model_spec):
         model_spec = transform_dict_to_frozendict(model_spec)
     deref = swagger_spec.fast_deref


### PR DESCRIPTION
Try to memoize the result of deref function in Spec class, and collapse_properties(), get_spec_for_prop() in Schema class. This can gain about 30% improvement on unmarshalling  performance.